### PR TITLE
Web server openiddict configuration

### DIFF
--- a/KinaUna.OpenIddict/HostingExtensions/OpenIddictConfiguration.cs
+++ b/KinaUna.OpenIddict/HostingExtensions/OpenIddictConfiguration.cs
@@ -34,7 +34,7 @@ namespace KinaUna.OpenIddict.HostingExtensions
                 {
                     options.LoginPath = "/login";
                     options.LogoutPath = "/logout";
-                    options.ExpireTimeSpan = TimeSpan.FromDays(60);
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(50);
                     options.SlidingExpiration = true;
                 });
         }

--- a/KinaUna.OpenIddict/KinaUna.OpenIddict.csproj
+++ b/KinaUna.OpenIddict/KinaUna.OpenIddict.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
     <PackageReference Include="OpenIddict" Version="7.0.0" />

--- a/KinaUna.OpenIddict/Program.cs
+++ b/KinaUna.OpenIddict/Program.cs
@@ -30,20 +30,27 @@ builder.Services.AddDataProtection()
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddTransient<IEmailSender, EmailSender>();
 builder.Services.AddTransient<ILocaleManager, LocaleManager>();
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews().AddViewLocalization();
+
+IMvcBuilder mvcBuilder = builder.Services.AddRazorPages();
+
+if (builder.Environment.IsDevelopment())
+{
+    mvcBuilder.AddRazorRuntimeCompilation();
+}
 
 
 // Register the OpenIddict services and configure them.
 string serverEncryptionCertificateThumbprint = builder.Configuration["ServerEncryptionCertificateThumbprint"] ?? throw new InvalidOperationException("ServerEncryptionCertificateThumbprint was not found in the configuration data.");
 string serverSigningCertificateThumbprint = builder.Configuration["ServerSigningCertificateThumbprint"] ?? throw new InvalidOperationException("ServerSigningCertificateThumbprint was not found in the configuration data.");
 
-// Replace the direct call to ConfigureOpenIddict with:
-builder.Services.AddSingleton<IOpenIddictConfigurator>(_ => 
-    new OpenIddictConfiguration(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint));
+//// Replace the direct call to ConfigureOpenIddict with:
+//builder.Services.AddSingleton<IOpenIddictConfigurator>(_ => 
+//    new OpenIddictConfiguration(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint));
 
-// Then resolve and use it
-builder.Services.AddSingleton<IOpenIddictConfigurator, OpenIddictConfiguration>(_ => 
-    new OpenIddictConfiguration(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint));
+//// Then resolve and use it
+//builder.Services.AddSingleton<IOpenIddictConfigurator, OpenIddictConfiguration>(_ => 
+//    new OpenIddictConfiguration(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint));
 
 builder.Services.AddSingleton<IOpenIddictConfigurator>(_ =>
 {

--- a/KinaUna.OpenIddict/Properties/launchSettings.json
+++ b/KinaUna.OpenIddict/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7238;http://localhost:5018",
+      "applicationUrl": "https://localhost:44397;http://localhost:5018",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/KinaUnaWeb/Controllers/AuthenticationController.cs
+++ b/KinaUnaWeb/Controllers/AuthenticationController.cs
@@ -1,0 +1,204 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
+using OpenIddict.Client.AspNetCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace KinaUnaWeb.Controllers
+{
+    // Reference: https://github.com/openiddict/openiddict-samples/blob/dev/samples/Velusia/Velusia.Client/Controllers/AuthenticationController.cs
+    public class AuthenticationController : Controller
+    {
+        [HttpGet("~/login")]
+        public ActionResult LogIn(string returnUrl)
+        {
+            AuthenticationProperties properties = new()
+            {
+                // Only allow local return URLs to prevent open redirect attacks.
+                RedirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/"
+            };
+
+            // Ask the OpenIddict client middleware to redirect the user agent to the identity provider.
+            return Challenge(properties, OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+        }
+
+        [HttpPost("~/logout"), ValidateAntiForgeryToken]
+        public async Task<ActionResult> LogOut(string returnUrl)
+        {
+            // Retrieve the identity stored in the local authentication cookie. If it's not available,
+            // this indicates that the user is already logged out locally (or has not logged in yet).
+            //
+            // For scenarios where the default authentication handler configured in the ASP.NET Core
+            // authentication options shouldn't be used, a specific scheme can be specified here.
+            AuthenticateResult result = await HttpContext.AuthenticateAsync();
+            if (result is not { Succeeded: true })
+            {
+                // Only allow local return URLs to prevent open redirect attacks.
+                return Redirect(Url.IsLocalUrl(returnUrl) ? returnUrl : "/");
+            }
+
+            // Remove the local authentication cookie before triggering a redirection to the remote server.
+            //
+            // For scenarios where the default sign-out handler configured in the ASP.NET Core
+            // authentication options shouldn't be used, a specific scheme can be specified here.
+            await HttpContext.SignOutAsync();
+
+            // If no properties were stored, redirect the user agent to the return URL.
+            if (result.Properties == null) return Redirect(Url.IsLocalUrl(returnUrl) ? returnUrl : "/");
+
+            AuthenticationProperties properties = new(new Dictionary<string, string>
+            {
+                // While not required, the specification encourages sending an id_token_hint
+                // parameter containing an identity token returned by the server for this user.
+                [OpenIddictClientAspNetCoreConstants.Properties.IdentityTokenHint] =
+                    result.Properties.GetTokenValue(OpenIddictClientAspNetCoreConstants.Tokens.BackchannelIdentityToken)
+            })
+            {
+                // Only allow local return URLs to prevent open redirect attacks.
+                RedirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/"
+            };
+
+            // Ask the OpenIddict client middleware to redirect the user agent to the identity provider.
+            return SignOut(properties, OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+        }
+        
+        // Note: this controller uses the same callback action for all providers
+        // but for users who prefer using a different action per provider,
+        // the following action can be split into separate actions.
+        [HttpGet("~/callback/login/{provider}"), HttpPost("~/callback/login/{provider}"), IgnoreAntiforgeryToken]
+        public async Task<ActionResult> LogInCallback()
+        {
+            // Retrieve the authorization data validated by OpenIddict as part of the callback handling.
+            AuthenticateResult result = await HttpContext.AuthenticateAsync(OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+
+            // Multiple strategies exist to handle OAuth 2.0/OpenID Connect callbacks, each with their pros and cons:
+            //
+            //   * Directly using the tokens to perform the necessary action(s) on behalf of the user, which is suitable
+            //     for applications that don't need long-term access to the user's resources or don't want to store
+            //     access/refresh tokens in a database or in an authentication cookie (which has security implications).
+            //     It is also suitable for applications that don't need to authenticate users but only need to perform
+            //     action(s) on their behalf by making API calls using the access token returned by the remote server.
+            //
+            //   * Storing the external claims/tokens in a database (and optionally keeping the essential claims in an
+            //     authentication cookie so that cookie size limits are not hit). For the applications that use ASP.NET
+            //     Core Identity, the UserManager.SetAuthenticationTokenAsync() API can be used to store external tokens.
+            //
+            //     Note: in this case, it's recommended to use column encryption to protect the tokens in the database.
+            //
+            //   * Storing the external claims/tokens in an authentication cookie, which doesn't require having
+            //     a user database but may be affected by the cookie size limits enforced by most browser vendors
+            //     (e.g. Safari for macOS and Safari for iOS/iPadOS enforce a per-domain 4KB limit for all cookies).
+            //
+            //     Note: this is the approach used here, but the external claims are first filtered to only persist
+            //     a few claims like the user identifier. The same approach is used to store the access/refresh tokens.
+
+            // Important: if the remote server doesn't support OpenID Connect and doesn't expose a userinfo endpoint,
+            // result.Principal.Identity will represent an unauthenticated identity and won't contain any user claim.
+            //
+            // Such identities cannot be used as-is to build an authentication cookie in ASP.NET Core (as the
+            // antiforgery stack requires at least a name claim to bind CSRF cookies to the user's identity) but
+            // the access/refresh tokens can be retrieved using result.Properties.GetTokens() to make API calls.
+            if (result is not { Succeeded: true, Principal.Identity.IsAuthenticated: true })
+            {
+                throw new InvalidOperationException("The external authorization data cannot be used for authentication.");
+            }
+
+            // Build an identity based on the external claims and that will be used to create the authentication cookie.
+            ClaimsIdentity identity = new(
+                authenticationType: "ExternalLogin",
+                nameType: ClaimTypes.Name,
+                roleType: ClaimTypes.Role);
+
+            // By default, OpenIddict will automatically try to map the email/name and name identifier claims from
+            // their standard OpenID Connect or provider-specific equivalent, if available. If needed, additional
+            // claims can be resolved from the external identity and copied to the final authentication cookie.
+            identity.SetClaim(ClaimTypes.Email, result.Principal.GetClaim(ClaimTypes.Email))
+                    .SetClaim(ClaimTypes.Name, result.Principal.GetClaim(ClaimTypes.Name))
+                    .SetClaim(ClaimTypes.NameIdentifier, result.Principal.GetClaim(ClaimTypes.NameIdentifier));
+
+            // Preserve the registration details to be able to resolve them later.
+            identity.SetClaim(Claims.Private.RegistrationId, result.Principal.GetClaim(Claims.Private.RegistrationId))
+                    .SetClaim(Claims.Private.ProviderName, result.Principal.GetClaim(Claims.Private.ProviderName));
+
+            // Important: when using ASP.NET Core Identity and its default UI, the identity created in this action is
+            // not directly persisted in the final authentication cookie (called "application cookie" by Identity) but
+            // in an intermediate authentication cookie called "external cookie" (the final authentication cookie is
+            // later created by Identity's ExternalLogin Razor Page by calling SignInManager.ExternalLoginSignInAsync()).
+            //
+            // Unfortunately, this process doesn't preserve the claims added here, which prevents flowing claims
+            // returned by the external provider down to the final authentication cookie. For scenarios that
+            // require that, the claims can be stored in Identity's database by calling UserManager.AddClaimAsync()
+            // directly in this action or by scaffolding the ExternalLogin.cshtml page that is part of the default UI:
+            // https://learn.microsoft.com/en-us/aspnet/core/security/authentication/social/additional-claims#add-and-update-user-claims.
+            //
+            // Alternatively, if flowing the claims from the "external cookie" to the "application cookie" is preferred,
+            // the default ExternalLogin.cshtml page provided by Identity can be scaffolded to replace the call to
+            // SignInManager.ExternalLoginSignInAsync() by a manual sign-in operation that will preserve the claims.
+            // For scenarios where scaffolding the ExternalLogin.cshtml page is not convenient, a custom SignInManager
+            // with an overridden SignInOrTwoFactorAsync() method can also be used to tweak the default Identity logic.
+            //
+            // For more information, see https://haacked.com/archive/2019/07/16/external-claims/ and
+            // https://stackoverflow.com/questions/42660568/asp-net-core-identity-extract-and-save-external-login-tokens-and-add-claims-to-l/42670559#42670559.
+
+            // Build the authentication properties based on the properties that were added when the challenge was triggered.
+            AuthenticationProperties properties = new(result.Properties.Items)
+            {
+                RedirectUri = result.Properties.RedirectUri ?? "/",
+
+                // Set the creation and expiration dates of the ticket to null to decorrelate the lifetime
+                // of the resulting authentication cookie from the lifetime of the identity token returned by
+                // the authorization server (if applicable). In this case, the expiration date time will be
+                // automatically computed by the cookie handler using the lifetime configured in the options.
+                //
+                // Applications that prefer binding the lifetime of the ticket stored in the authentication cookie
+                // to the identity token returned by the identity provider can remove or comment these two lines:
+                IssuedUtc = null,
+                ExpiresUtc = null,
+
+                // Note: this flag controls whether the authentication cookie that will be returned to the
+                // browser will be treated as a session cookie (i.e destroyed when the browser is closed)
+                // or as a persistent cookie. In both cases, the lifetime of the authentication ticket is
+                // always stored as protected data, preventing malicious users from trying to use an
+                // authentication cookie beyond the lifetime of the authentication ticket itself.
+                IsPersistent = false
+            };
+
+            // If needed, the tokens returned by the authorization server can be stored in the authentication cookie.
+            //
+            // To make cookies less heavy, tokens that are not used are filtered out before creating the cookie.
+            properties.StoreTokens(result.Properties.GetTokens().Where(token => token.Name is
+                // Preserve the access, identity and refresh tokens returned in the token response, if available.
+                OpenIddictClientAspNetCoreConstants.Tokens.BackchannelAccessToken or
+                OpenIddictClientAspNetCoreConstants.Tokens.BackchannelIdentityToken or
+                OpenIddictClientAspNetCoreConstants.Tokens.RefreshToken));
+
+            // Ask the default sign-in handler to return a new cookie and redirect the
+            // user agent to the return URL stored in the authentication properties.
+            //
+            // For scenarios where the default sign-in handler configured in the ASP.NET Core
+            // authentication options shouldn't be used, a specific scheme can be specified here.
+            return SignIn(new ClaimsPrincipal(identity), properties);
+        }
+
+        // Note: this controller uses the same callback action for all providers
+        // but for users who prefer using a different action per provider,
+        // the following action can be split into separate actions.
+        [HttpGet("~/callback/logout/{provider}"), HttpPost("~/callback/logout/{provider}"), IgnoreAntiforgeryToken]
+        public async Task<ActionResult> LogOutCallback()
+        {
+            // Retrieve the data stored by OpenIddict in the state token created when the logout was triggered.
+            AuthenticateResult result = await HttpContext.AuthenticateAsync(OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
+
+            // In this sample, the local authentication cookie is always removed before the user agent is redirected
+            // to the authorization server. Applications that prefer delaying the removal of the local cookie can
+            // remove the corresponding code from the logout action and remove the authentication cookie in this action.
+
+            return Redirect(result.Properties?.RedirectUri ?? "/");
+        }
+    }
+}

--- a/KinaUnaWeb/HostingExtensions/Interfaces/ICertificateProvider.cs
+++ b/KinaUnaWeb/HostingExtensions/Interfaces/ICertificateProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace KinaUnaWeb.HostingExtensions.Interfaces
+{
+    public interface ICertificateProvider
+    {
+        X509Certificate2 GetCertificate(string thumbprint);
+    }
+
+    public class DefaultCertificateProvider : ICertificateProvider
+    {
+        public X509Certificate2 GetCertificate(string thumbprint)
+        {
+            X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            try
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                // Place all certificates in an X509Certificate2Collection object.
+                X509Certificate2Collection certCollection = store.Certificates;
+                // If using a certificate with a trusted root you do not need to FindByTimeValid, instead:
+                // currentCerts.Find(X509FindType.FindBySubjectDistinguishedName, certName, true);
+                X509Certificate2Collection currentCerts = certCollection.Find(X509FindType.FindByTimeValid, DateTime.Now, false);
+                X509Certificate2Collection signingCert = currentCerts.Find(X509FindType.FindByThumbprint, thumbprint, false);
+                if (signingCert.Count == 0)
+                    throw new CryptographicException($"Certificate with thumbprint {thumbprint} not found in the current user's certificate store.");
+                // Return the first certificate in the collection, has the thumbprint and is current.
+                return signingCert[0];
+            }
+            finally
+            {
+                store.Close();
+            }
+        }
+    }
+}

--- a/KinaUnaWeb/HostingExtensions/Interfaces/ICertificateProvider.cs
+++ b/KinaUnaWeb/HostingExtensions/Interfaces/ICertificateProvider.cs
@@ -25,7 +25,7 @@ namespace KinaUnaWeb.HostingExtensions.Interfaces
                 X509Certificate2Collection currentCerts = certCollection.Find(X509FindType.FindByTimeValid, DateTime.Now, false);
                 X509Certificate2Collection signingCert = currentCerts.Find(X509FindType.FindByThumbprint, thumbprint, false);
                 if (signingCert.Count == 0)
-                    throw new CryptographicException($"Certificate with thumbprint {thumbprint} not found in the current user's certificate store.");
+                    throw new CryptographicException($"Certificate with thumbprint {thumbprint} not found in the current user's certificate store. Please verify that the certificate is installed and ensure you are checking the correct certificate store location (e.g., CurrentUser or LocalMachine).");
                 // Return the first certificate in the collection, has the thumbprint and is current.
                 return signingCert[0];
             }

--- a/KinaUnaWeb/HostingExtensions/Interfaces/IOpenIddictConfigurator.cs
+++ b/KinaUnaWeb/HostingExtensions/Interfaces/IOpenIddictConfigurator.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KinaUnaWeb.HostingExtensions.Interfaces
+{
+    public interface IOpenIddictConfigurator
+    {
+        void ConfigureServices(IServiceCollection services);
+    }
+}

--- a/KinaUnaWeb/HostingExtensions/OpenIddictConfiguration.cs
+++ b/KinaUnaWeb/HostingExtensions/OpenIddictConfiguration.cs
@@ -1,0 +1,148 @@
+﻿using KinaUna.Data.Contexts;
+using KinaUnaWeb.HostingExtensions.Interfaces;
+using KinaUnaWeb.Services;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using OpenIddict.Client;
+using Quartz;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace KinaUnaWeb.HostingExtensions
+{
+    public class OpenIddictConfiguration(
+        string serverEncryptionCertificateThumbprint,
+        string serverSigningCertificateThumbprint,
+        string clientId,
+        string clientSecret,
+        string issuer,
+        ICertificateProvider certificateProvider = null)
+        : IOpenIddictConfigurator
+    {
+        private readonly ICertificateProvider _certificateProvider = certificateProvider ?? new DefaultCertificateProvider();
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            ConfigureAuthentication(services);
+            ConfigureQuartz(services);
+            ConfigureOpenIddict(services);
+        }
+
+        private static void ConfigureAuthentication(IServiceCollection services)
+        {
+            services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            }).AddCookie(options =>
+              {
+                  options.LoginPath = "/login";
+                  options.LogoutPath = "/logout";
+                  options.ExpireTimeSpan = TimeSpan.FromMinutes(50);
+                  options.SlidingExpiration = false;
+              });
+        }
+        
+        private static void ConfigureQuartz(IServiceCollection services)
+        {
+            services.AddQuartz(options =>
+            {
+                options.UseSimpleTypeLoader();
+                options.UseInMemoryStore();
+            });
+
+            services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+        }
+
+        private void ConfigureOpenIddict(IServiceCollection services)
+        {
+            services.AddOpenIddict()
+
+                // Register the OpenIddict core components.
+                .AddCore(options =>
+                {
+                    // Configure OpenIddict to use the Entity Framework Core stores and models.
+                    // Note: call ReplaceDefaultEntities() to replace the default OpenIddict entities.
+                    options.UseEntityFrameworkCore()
+                            .UseDbContext<ApplicationDbContext>();
+
+                    // Developers who prefer using MongoDB can remove the previous lines
+                    // and configure OpenIddict to use the specified MongoDB database:
+                    // options.UseMongoDb()
+                    //        .UseDatabase(new MongoClient().GetDatabase("openiddict"));
+
+                    // Enable Quartz.NET integration.
+                    options.UseQuartz();
+                })
+
+                // Register the OpenIddict client components.
+                .AddClient(options =>
+                {
+                    // Note: this sample uses the code flow, but you can enable the other flows if necessary.
+                    options.AllowAuthorizationCodeFlow();
+                    
+                    // Register the signing and encryption credentials used to protect
+                    // sensitive data like the state tokens produced by OpenIddict.
+                    ConfigureCertificates(options);
+
+                    // Register the ASP.NET Core host and configure the ASP.NET Core-specific options.
+                    ConfigureAspNetCore(options);
+
+                    // Register the System.Net.Http integration and use the identity of the current
+                    // assembly as a more specific user agent, which can be useful when dealing with
+                    // providers that use the user agent as a way to throttle requests (e.g Reddit).
+                    options.UseSystemNetHttp()
+                            .SetProductInformation(typeof(Startup).Assembly);
+
+                    // Add a client registration matching the client application definition in the server project.
+                    options.AddRegistration(new OpenIddictClientRegistration
+                    {
+                        Issuer = new Uri(issuer, UriKind.Absolute),
+
+                        ClientId = clientId,
+                        ClientSecret = clientSecret,
+                        Scopes = { OpenIddictConstants.Permissions.Scopes.Email, OpenIddictConstants.Permissions.Scopes.Profile },
+
+                        // Note: to mitigate mix-up attacks, it's recommended to use a unique redirection endpoint
+                        // URI per provider, unless all the registered providers support returning a special "iss"
+                        // parameter containing their URL as part of authorization responses. For more information,
+                        // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
+                        RedirectUri = new Uri("callback/login/local", UriKind.Relative),
+                        PostLogoutRedirectUri = new Uri("callback/logout/local", UriKind.Relative)
+                    });
+                }).AddValidation(options =>
+                {
+                    ConfigureValidationCertificates(options);
+                    options.UseAspNetCore();
+                });
+
+            services.AddHostedService<OpenIddictWorkerService>();
+        }
+        
+        private void ConfigureCertificates(OpenIddictClientBuilder options)
+        {
+            X509Certificate2 encryptionCertificate = _certificateProvider.GetCertificate(serverEncryptionCertificateThumbprint);
+            X509Certificate2 signingCertificate = _certificateProvider.GetCertificate(serverSigningCertificateThumbprint);
+            
+            options.AddEncryptionCertificate(encryptionCertificate);
+            options.AddSigningCertificate(signingCertificate);
+        }
+
+        private static void ConfigureAspNetCore(OpenIddictClientBuilder options)
+        {
+            options.UseAspNetCore()
+                .EnableStatusCodePagesIntegration()
+                .EnableRedirectionEndpointPassthrough()
+                .EnablePostLogoutRedirectionEndpointPassthrough();
+        }
+
+        private void ConfigureValidationCertificates(OpenIddictValidationBuilder options)
+        {
+            X509Certificate2 encryptionCertificate = _certificateProvider.GetCertificate(serverEncryptionCertificateThumbprint);
+            X509Certificate2 signingCertificate = _certificateProvider.GetCertificate(serverSigningCertificateThumbprint);
+            
+            options.AddEncryptionCertificate(encryptionCertificate);
+            options.AddSigningCertificate(signingCertificate);
+        }
+    }
+}

--- a/KinaUnaWeb/KinaUnaWeb.csproj
+++ b/KinaUnaWeb/KinaUnaWeb.csproj
@@ -84,8 +84,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IdentityModel" Version="4.6.0" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
@@ -101,7 +99,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="OpenIddict.Quartz" Version="7.0.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
     <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="26.2.14" />
     <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.CodeDom" Version="9.0.7" />

--- a/KinaUnaWeb/Services/OpenIddictWorkerService.cs
+++ b/KinaUnaWeb/Services/OpenIddictWorkerService.cs
@@ -1,0 +1,23 @@
+﻿using KinaUna.Data.Contexts;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KinaUnaWeb.Services
+{
+    public class OpenIddictWorkerService(IServiceProvider serviceProvider) : IHostedService
+    {
+        
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            await using AsyncServiceScope scope = serviceProvider.CreateAsyncScope();
+
+            ApplicationDbContext context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await context.Database.EnsureCreatedAsync(cancellationToken);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/KinaUnaWeb/Startup.cs
+++ b/KinaUnaWeb/Startup.cs
@@ -50,7 +50,7 @@ namespace KinaUnaWeb
                 options.Secure = CookieSecurePolicy.Always;
             });
 
-            string authOpenIddictClientConnection = Configuration["AuthOpenIddictClientConnection"] ?? throw new InvalidOperationException("AuthDefaultConnection was not found in the configuration data.");
+            string authOpenIddictClientConnection = Configuration["AuthOpenIddictClientConnection"] ?? throw new InvalidOperationException("AuthOpenIddictClientConnection was not found in the configuration data.");
             services.AddDbContext<ApplicationDbContext>(options =>
             {
                 options.UseSqlServer(authOpenIddictClientConnection,

--- a/KinaUnaWeb/Startup.cs
+++ b/KinaUnaWeb/Startup.cs
@@ -108,7 +108,7 @@ namespace KinaUnaWeb
 
             string authorityServerUrl = Configuration.GetValue<string>("AuthenticationServer");
             string authenticationServerClientId = Configuration.GetValue<string>("AuthenticationServerClientId");
-            string authenticationServerClientSecret = Configuration.GetValue<string>("AuthenticationServerClientSecret");
+            string authenticationServerClientSecret = Configuration.GetValue<string>("OpenIddictSecretString");
             string progenyServerUrl = Configuration.GetValue<string>("ProgenyApiServer"); 
             string mediaServerUrl = Configuration.GetValue<string>("MediaApiServer");
 
@@ -117,6 +117,7 @@ namespace KinaUnaWeb
                                                            throw new InvalidOperationException("ServerEncryptionCertificateThumbprint was not found in the configuration data.");
             string serverSigningCertificateThumbprint = Configuration["ServerSigningCertificateThumbprint"] ??
                                                         throw new InvalidOperationException("ServerSigningCertificateThumbprint was not found in the configuration data.");
+            
             services.AddSingleton<IOpenIddictConfigurator>(_ =>
             {
                 OpenIddictConfiguration config = new(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint, authenticationServerClientId, authenticationServerClientSecret, authorityServerUrl);

--- a/KinaUnaWeb/Startup.cs
+++ b/KinaUnaWeb/Startup.cs
@@ -154,9 +154,9 @@ namespace KinaUnaWeb
             app.UseCookiePolicy();
             CultureInfo[] supportedCultures =
             [
-                new CultureInfo("en-US"),
-                new CultureInfo("da-DK"),
-                new CultureInfo("de-DE"),
+                new("en-US"),
+                new("da-DK"),
+                new("de-DE"),
             ];
 
             RequestLocalizationOptions localizationOptions = new()
@@ -187,8 +187,7 @@ namespace KinaUnaWeb
                 app.UseExceptionHandler("/Home/Error");
                 app.UseHsts();
             }
-
-            // app.UseCors("KinaUnaCors");
+            
             app.UseHttpsRedirection();
             app.UseAuthentication();
             app.UseAuthorization();

--- a/KinaUnaWeb/Startup.cs
+++ b/KinaUnaWeb/Startup.cs
@@ -1,8 +1,11 @@
-﻿using IdentityModel;
+﻿using Azure.Storage.Blobs;
+using KinaUna.Data;
+using KinaUna.Data.Contexts;
+using KinaUna.Data.Models;
+using KinaUnaWeb.Hubs;
 using KinaUnaWeb.Services;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using KinaUnaWeb.Services.HttpClients;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -10,22 +13,17 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.Hosting;
 using System;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
-using System.Threading.Tasks;
-using KinaUna.Data.Models;
-using KinaUnaWeb.Hubs;
+using KinaUnaWeb.HostingExtensions;
+using KinaUnaWeb.HostingExtensions.Interfaces;
 using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
-using KinaUna.Data;
-using KinaUnaWeb.Services.HttpClients;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Hosting;
-using Azure.Storage.Blobs;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
 namespace KinaUnaWeb
 {
@@ -51,17 +49,25 @@ namespace KinaUnaWeb
                 options.MinimumSameSitePolicy = SameSiteMode.Lax;
                 options.Secure = CookieSecurePolicy.Always;
             });
-            
+
+            string authOpenIddictClientConnection = Configuration["AuthOpenIddictClientConnection"] ?? throw new InvalidOperationException("AuthDefaultConnection was not found in the configuration data.");
+            services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseSqlServer(authOpenIddictClientConnection,
+                    sqlServerOptionsAction: sqlOptions =>
+                    {
+                        //Configuring Connection Resiliency: https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency 
+                        sqlOptions.EnableRetryOnFailure(maxRetryCount: 15, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null);
+                    });
+                options.UseOpenIddict(); // Add this line to enable OpenIddict support
+            });
+
             string storageConnectionString = Configuration["BlobStorageConnectionString"];
             new BlobContainerClient(storageConnectionString, "dataprotection").CreateIfNotExists();
 
             services.AddDataProtection()
                 .SetApplicationName("KinaUnaWebApp")
                 .PersistKeysToAzureBlobStorage(storageConnectionString, "dataprotection", "kukeys.xml");
-
-            string authorityServerUrl = Configuration.GetValue<string>("AuthenticationServer");
-            string authenticationServerClientId = Configuration.GetValue<string>("AuthenticationServerClientId");
-            string authenticationServerClientSecret = Configuration.GetValue<string>("AuthenticationServerClientSecret");
 
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<ILocaleManager, LocaleManager>();
@@ -99,41 +105,26 @@ namespace KinaUnaWeb
             services.AddTransient<ITimeLineItemsService, TimeLineItemsService>();
             services.AddHttpClient<IAutoSuggestsHttpClient, AutoSuggestsHttpClient>();
             services.AddDistributedMemoryCache();
-            
+
+            string authorityServerUrl = Configuration.GetValue<string>("AuthenticationServer");
+            string authenticationServerClientId = Configuration.GetValue<string>("AuthenticationServerClientId");
+            string authenticationServerClientSecret = Configuration.GetValue<string>("AuthenticationServerClientSecret");
             string progenyServerUrl = Configuration.GetValue<string>("ProgenyApiServer"); 
             string mediaServerUrl = Configuration.GetValue<string>("MediaApiServer");
 
-            services.Configure<AuthConfigurations>(config => { config.StsServer = authorityServerUrl; config.ProtectedApiUrl = progenyServerUrl + " " + mediaServerUrl;});
-            
-            //services.AddCors(o =>
-            //{
-            //    if (_env.IsDevelopment())
-            //    {
-            //        o.AddDefaultPolicy(builder =>
-            //        {
-            //            builder.WithOrigins("https://*.kinauna.io", "https://nuuk2015.kinauna.io:44324",
-            //                "https://nuuk2020.kinauna.io:44324", "https://nuuk2015.kinauna.io:44397",
-            //                "https://nuuk2020.kinauna.io:44397", "https://nuuk2015.kinauna.io",
-            //                "https://nuuk2020.kinauna.io").SetIsOriginAllowedToAllowWildcardSubdomains().AllowAnyHeader().AllowAnyMethod().AllowCredentials();
-            //        });
-            //    }
+            // Register the OpenIddict services and configure them.
+            string serverEncryptionCertificateThumbprint = Configuration["ServerEncryptionCertificateThumbprint"] ??
+                                                           throw new InvalidOperationException("ServerEncryptionCertificateThumbprint was not found in the configuration data.");
+            string serverSigningCertificateThumbprint = Configuration["ServerSigningCertificateThumbprint"] ??
+                                                        throw new InvalidOperationException("ServerSigningCertificateThumbprint was not found in the configuration data.");
+            services.AddSingleton<IOpenIddictConfigurator>(_ =>
+            {
+                OpenIddictConfiguration config = new(serverEncryptionCertificateThumbprint, serverSigningCertificateThumbprint, authenticationServerClientId, authenticationServerClientSecret, authorityServerUrl);
+                config.ConfigureServices(services);
+                return config;
+            });
 
-            //    o.AddPolicy("KinaUnaCors", builder =>
-            //    {
-            //        if (_env.IsDevelopment())
-            //        {
-            //            builder.WithOrigins("https://*.kinauna.io", "https://nuuk2015.kinauna.io:44324",
-            //                    "https://nuuk2020.kinauna.io:44324", "https://nuuk2015.kinauna.io:44397",
-            //                    "https://nuuk2020.kinauna.io:44397", "https://nuuk2015.kinauna.io",
-            //                    "https://nuuk2020.kinauna.io").SetIsOriginAllowedToAllowWildcardSubdomains().AllowAnyHeader().AllowAnyMethod().AllowCredentials();
-            //        }
-            //        else
-            //        {
-            //            builder.WithOrigins("https://*." + Constants.AppRootDomain)
-            //                .SetIsOriginAllowedToAllowWildcardSubdomains().AllowAnyHeader().AllowAnyMethod().AllowCredentials();
-            //        }
-            //    });
-            //});
+            services.Configure<AuthConfigurations>(config => { config.StsServer = authorityServerUrl; config.ProtectedApiUrl = progenyServerUrl + " " + mediaServerUrl;});
             
             services.AddControllersWithViews(options =>
             {
@@ -141,68 +132,15 @@ namespace KinaUnaWeb
                     .RequireAuthenticatedUser()
                     .Build();
                 options.Filters.Add(new AuthorizeFilter(policy));
-            }).AddNewtonsoftJson().AddViewLocalization()
-            .AddRazorRuntimeCompilation();
+            }).AddNewtonsoftJson().AddViewLocalization();
 
-            services.AddAuthentication(options =>
-                {
-                    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
-            }).AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options =>
-                {
-                    options.Cookie.Name = "KinaUnaCookie";
-                    options.SlidingExpiration = true;
-                    options.Events.OnSigningIn = (context) =>
-                    {
-                        context.CookieOptions.Expires = DateTimeOffset.UtcNow.AddDays(30);
-                        return Task.CompletedTask;
-                    };
+            IMvcBuilder mvcBuilder = services.AddRazorPages();
 
-                    if (!_env.IsDevelopment())
-                    {
-                        options.Cookie.Domain = "web." + Constants.AppRootDomain;
-
-                    }
-                })
-                .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, options =>
-                {
-                    options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    options.Authority = authorityServerUrl;
-                    options.ClientId = authenticationServerClientId;
-                    options.ResponseType = OidcConstants.ResponseTypes.Code;
-                    options.UsePkce = true;
-                    options.RequireHttpsMetadata = true;
-                    options.Scope.Add("openid");
-                    options.Scope.Add("profile");
-                    options.Scope.Add("email");
-                    options.Scope.Add("roles");
-                    options.Scope.Add("timezone");
-                    options.Scope.Add("joindate");
-                    options.Scope.Add("viewchild");
-                    options.Scope.Add(Constants.ProgenyApiName);
-                    options.Scope.Add(Constants.MediaApiName);
-                    options.Scope.Add("offline_access");
-                    options.SaveTokens = true;
-                    options.ClientSecret = authenticationServerClientSecret;
-                    options.GetClaimsFromUserInfoEndpoint = true;
-                    options.ClaimActions.Remove("amr");
-                    options.ClaimActions.DeleteClaim("sid");
-                    options.ClaimActions.DeleteClaim("idp");
-                    options.ClaimActions.MapUniqueJsonKey("role", "role");
-                    options.ClaimActions.MapUniqueJsonKey("timezone", "timezone");
-                    options.ClaimActions.MapUniqueJsonKey("email", "email");
-                    options.ClaimActions.MapUniqueJsonKey("email_verified", "email_verified");
-                    options.ClaimActions.MapUniqueJsonKey("viewchild", "viewchild");
-                    options.ClaimActions.MapUniqueJsonKey("joindate", "joindate");
-                    options.ClaimActions.MapUniqueJsonKey("preferred_username", "preferred_username");
-                    options.MapInboundClaims = false; // Prevents IdentityModel from mapping claims automatically, we want to use the original claim types from IdentityServer
-                    options.TokenValidationParameters = new TokenValidationParameters
-                    {
-                        NameClaimType = JwtClaimTypes.Email,
-                        RoleClaimType = JwtClaimTypes.Role
-                    };
-                    
-                });
+            if (_env.IsDevelopment())
+            {
+                mvcBuilder.AddRazorRuntimeCompilation();
+            }
+            
             services.AddAuthorization();
             services.AddSignalR().AddMessagePackProtocol().AddNewtonsoftJsonProtocol();
             services.AddSingleton<IUserIdProvider, CustomUserIdProvider>();


### PR DESCRIPTION
This pull request introduces significant updates to the authentication system, dependency management, and application configuration. The changes include implementing a new `AuthenticationController` for OpenID Connect workflows, adding runtime Razor compilation for development, updating session expiration settings, and introducing new interfaces for certificate and OpenIddict configuration.

### Authentication Enhancements:
* Added a new `AuthenticationController` in `KinaUnaWeb/Controllers/AuthenticationController.cs` to handle OpenID Connect login, logout, and callback workflows. This implementation includes safeguards against open redirect attacks and supports token management for external claims.

### Dependency and Configuration Updates:
* Updated `KinaUna.OpenIddict.csproj` to include the `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` package for runtime Razor view compilation.
* Modified `Program.cs` to enable view localization and conditionally add Razor runtime compilation in development environments.

### Session and Security Adjustments:
* Changed the session expiration time in `OpenIddictConfiguration.cs` from 60 days to 50 minutes to enhance security.
* Updated the `applicationUrl` in `launchSettings.json` to use a new HTTPS port (`https://localhost:44397`).

### New Interfaces for Extensibility:
* Introduced `ICertificateProvider` and its default implementation to retrieve certificates by thumbprint, improving certificate management.
* Added `IOpenIddictConfigurator` interface to abstract OpenIddict service configuration.