### PR TITLE
117 create initial database migrations for todoitems

### DIFF
--- a/KinaUna.Data/Contexts/ProgenyDbContext.cs
+++ b/KinaUna.Data/Contexts/ProgenyDbContext.cs
@@ -32,5 +32,6 @@ namespace KinaUna.Data.Contexts
         public DbSet<CalendarReminder> CalendarRemindersDb { get; init; }
         public DbSet<ProgenyInfo> ProgenyInfoDb { get; init; }
         public DbSet<RecurrenceRule> RecurrenceRulesDb { get; init; }
+        public DbSet<TodoItem> TodoItemsDb { get; init; }
     }
 }

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.Designer.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.Designer.cs
@@ -4,16 +4,19 @@ using KinaUna.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace KinaUna.IDP.Migrations.ProgenyDb
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
 {
     [DbContext(typeof(ProgenyDbContext))]
-    partial class ProgenyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250804080142_AddTodoItemsDbSet")]
+    partial class AddTodoItemsDbSet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
+{
+    /// <inheritdoc />
+    public partial class AddTodoItemsDbSet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TodoItemsDb",
+                columns: table => new
+                {
+                    TodoItemId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ProgenyId = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    DueDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CompletedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AccessLevel = table.Column<int>(type: "int", nullable: false),
+                    Tags = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Context = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TodoItemsDb", x => x.TodoItemId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TodoItemsDb");
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `TodoItemsDb` entity to the `ProgenyDbContext` and updates the database schema to support it. The changes include adding the necessary DbSet, creating a migration for the new table, and updating the model snapshot to reflect the schema changes.

### Database Schema Updates:

* Added a new `DbSet` for `TodoItemsDb` in `ProgenyDbContext` to manage `TodoItem` entities. (`KinaUna.Data/Contexts/ProgenyDbContext.cs`, [KinaUna.Data/Contexts/ProgenyDbContext.csR35](diffhunk://#diff-59c6d01d015b0d6feaf5efd859661b71c48eb7903ae2d461ac936460bf00e0cbR35))
* Created a migration (`AddTodoItemsDbSet`) to define the `TodoItemsDb` table, including columns such as `TodoItemId`, `ProgenyId`, `Title`, `Description`, `Status`, `DueDate`, `CompletedDate`, and others. (`KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.cs`, [KinaUna.OpenIddict/Migrations/ProgenyDb/20250804080142_AddTodoItemsDbSet.csR1-R49](diffhunk://#diff-b8ebb6db31ddf92a9e88035b157587818c213e976cf0d6f8411e140ad536cf4eR1-R49))

### Model Snapshot Updates:

* Updated the `ProgenyDbContextModelSnapshot` to include the new `TodoItemsDb` table and its schema definition. (`KinaUna.OpenIddict/Migrations/ProgenyDb/ProgenyDbContextModelSnapshot.cs`, [KinaUna.OpenIddict/Migrations/ProgenyDb/ProgenyDbContextModelSnapshot.csR902-R959](diffhunk://#diff-e717d7f321b9ab896c3fb4c83636608b19c68bb84667ffa64dbe996bb7b577b3R902-R959))
* Updated the EF Core version annotation in the model snapshot from `8.0.10` to `9.0.7`. (`KinaUna.OpenIddict/Migrations/ProgenyDb/ProgenyDbContextModelSnapshot.cs`, [KinaUna.OpenIddict/Migrations/ProgenyDb/ProgenyDbContextModelSnapshot.csL20-R20](diffhunk://#diff-e717d7f321b9ab896c3fb4c83636608b19c68bb84667ffa64dbe996bb7b577b3L20-R20))