### PR TITLE
147 add kanbanitem entity to handle statuscolumn data for todoitems

### DIFF
--- a/KinaUna.Data/Contexts/ProgenyDbContext.cs
+++ b/KinaUna.Data/Contexts/ProgenyDbContext.cs
@@ -33,5 +33,7 @@ namespace KinaUna.Data.Contexts
         public DbSet<ProgenyInfo> ProgenyInfoDb { get; init; }
         public DbSet<RecurrenceRule> RecurrenceRulesDb { get; init; }
         public DbSet<TodoItem> TodoItemsDb { get; init; }
+        public DbSet<KanbanItem> KanbanItemsDb { get; init; }
+        public DbSet<KanbanBoard> KanbanBoardsDb { get; init; }
     }
 }

--- a/KinaUna.Data/Models/KanbanBoard.cs
+++ b/KinaUna.Data/Models/KanbanBoard.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace KinaUna.Data.Models

--- a/KinaUna.Data/Models/KanbanBoard.cs
+++ b/KinaUna.Data/Models/KanbanBoard.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace KinaUna.Data.Models
+{
+    /// <summary>
+    /// Represents a Kanban board, which is a visual tool for organizing tasks and workflows.
+    /// </summary>
+    /// <remarks>A Kanban board typically consists of tasks organized into columns that represent different
+    /// stages of a workflow. This class provides properties to store metadata about the board, such as its name,
+    /// creation and modification timestamps, and the users who created or last modified it.</remarks>
+    public class KanbanBoard
+    {
+        [Key]
+        public int KanbanBoardId { get; set; }
+        [MaxLength(128)]
+        public string UId { get; set; } = string.Empty;
+        public int ProgenyId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        [MaxLength(4096)]
+        public string Description { get; set; } = string.Empty;
+        public string Columns { get; set; } // JSON representation of the columns in the Kanban board.
+        public DateTime CreatedTime { get; set; }
+        public DateTime ModifiedTime { get; set; }
+        [MaxLength(256)] public string CreatedBy { get; set; } = string.Empty;
+        [MaxLength(256)] public string ModifiedBy { get; set; } = string.Empty;
+        public int AccessLevel { get; set; }
+    }
+}

--- a/KinaUna.Data/Models/KanbanItem.cs
+++ b/KinaUna.Data/Models/KanbanItem.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace KinaUna.Data.Models
+{
+    /// <summary>
+    /// Represents an item on a Kanban board, linking a to-do item to a specific position within a board column and row.
+    /// </summary>
+    /// <remarks>A <see cref="KanbanItem"/> is associated with a specific Kanban board and to-do item, and it
+    /// tracks its position within the board using column and row indices. It also includes metadata such as creation
+    /// and modification timestamps and user information.</remarks>
+    public class KanbanItem
+    {
+        [Key]
+        public int KanbanItemId { get; set; }
+        [MaxLength(128)]
+        public string UId { get; set; } = string.Empty;
+        public int KanbanBoardId { get; set; }
+        public int TodoItemId { get; set; }
+        public int ColumnIndex { get; set; }
+        public int RowIndex { get; set; }
+        public DateTime CreatedTime { get; set; }
+        public DateTime ModifiedTime { get; set; }
+        [MaxLength(256)]
+        public string CreatedBy { get; set; } = string.Empty;
+        [MaxLength(256)]
+        public string ModifiedBy { get; set; } = string.Empty;
+    }
+}

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.Designer.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.Designer.cs
@@ -4,16 +4,19 @@ using KinaUna.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace KinaUna.IDP.Migrations.ProgenyDb
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
 {
     [DbContext(typeof(ProgenyDbContext))]
-    partial class ProgenyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250826144956_InitialAddKanbanEntities")]
+    partial class InitialAddKanbanEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250826144956_InitialAddKanbanEntities.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
+{
+    /// <inheritdoc />
+    public partial class InitialAddKanbanEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "KanbanBoardsDb",
+                columns: table => new
+                {
+                    KanbanBoardId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UId = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                    ProgenyId = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", maxLength: 4096, nullable: true),
+                    Columns = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    AccessLevel = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KanbanBoardsDb", x => x.KanbanBoardId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "KanbanItemsDb",
+                columns: table => new
+                {
+                    KanbanItemId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UId = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
+                    KanbanBoardId = table.Column<int>(type: "int", nullable: false),
+                    TodoItemId = table.Column<int>(type: "int", nullable: false),
+                    ColumnIndex = table.Column<int>(type: "int", nullable: false),
+                    RowIndex = table.Column<int>(type: "int", nullable: false),
+                    CreatedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KanbanItemsDb", x => x.KanbanItemId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "KanbanBoardsDb");
+
+            migrationBuilder.DropTable(
+                name: "KanbanItemsDb");
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces support for Kanban boards and items to the data model. It adds new entity classes for Kanban boards and items, updates the database context to include these entities, and provides the necessary database migrations to create the corresponding tables.

**Kanban board and item support:**

* Added new entity classes `KanbanBoard` and `KanbanItem` in `KinaUna.Data.Models`, including properties for metadata, structure, and user information. [[1]](diffhunk://#diff-8fa888e6c0b17eac06694bb41e344c51b3937bb5035e9236a3d58c66031e933fR1-R29) [[2]](diffhunk://#diff-1cfa4a77125403bae6df3a70686b8f493ce0efd356c549462783fad862d40fd9R1-R29)
* Updated `ProgenyDbContext` to include `KanbanBoardsDb` and `KanbanItemsDb` as new `DbSet` properties.

**Database migration and schema updates:**

* Added a migration (`20250826144956_InitialAddKanbanEntities.cs`) to create the `KanbanBoardsDb` and `KanbanItemsDb` tables in the database, with appropriate columns and constraints.
* Updated the Entity Framework model snapshot in `ProgenyDbContextModelSnapshot.cs` to reflect the new Kanban entities and their schema definitions.