### PR TITLE
161 access management   phase 2

### DIFF
--- a/KinaUna.Data/Contexts/ProgenyDbContext.cs
+++ b/KinaUna.Data/Contexts/ProgenyDbContext.cs
@@ -46,5 +46,6 @@ namespace KinaUna.Data.Contexts
         public DbSet<TimelineItemPermission> TimelineItemPermissionsDb { get; init; }
         public DbSet<PermissionAuditLog> PermissionAuditLogsDb { get; init; }
         public DbSet<FamilyAuditLog> FamilyAuditLogsDb { get; init; }
+        public DbSet<UserGroupAuditLog> UserGroupAuditLogsDb { get; init; }
     }
 }

--- a/KinaUna.Data/Contexts/ProgenyDbContext.cs
+++ b/KinaUna.Data/Contexts/ProgenyDbContext.cs
@@ -44,5 +44,6 @@ namespace KinaUna.Data.Contexts
         public DbSet<FamilyPermission> FamilyPermissionsDb { get; init; }
         public DbSet<ProgenyPermission> ProgenyPermissionsDb { get; init; }
         public DbSet<TimelineItemPermission> TimelineItemPermissionsDb { get; init; }
+        public DbSet<PermissionAuditLog> PermissionAuditLogsDb { get; init; }
     }
 }

--- a/KinaUna.Data/Contexts/ProgenyDbContext.cs
+++ b/KinaUna.Data/Contexts/ProgenyDbContext.cs
@@ -45,5 +45,6 @@ namespace KinaUna.Data.Contexts
         public DbSet<ProgenyPermission> ProgenyPermissionsDb { get; init; }
         public DbSet<TimelineItemPermission> TimelineItemPermissionsDb { get; init; }
         public DbSet<PermissionAuditLog> PermissionAuditLogsDb { get; init; }
+        public DbSet<FamilyAuditLog> FamilyAuditLogsDb { get; init; }
     }
 }

--- a/KinaUna.Data/Models/AccessManagement/PermissionAction.cs
+++ b/KinaUna.Data/Models/AccessManagement/PermissionAction.cs
@@ -1,0 +1,10 @@
+﻿namespace KinaUna.Data.Models.AccessManagement
+{
+    public enum PermissionAction
+    {
+        Unknown = 0,
+        Add = 1,
+        Update = 2,
+        Delete = 3 
+    }
+}

--- a/KinaUna.Data/Models/AccessManagement/PermissionAction.cs
+++ b/KinaUna.Data/Models/AccessManagement/PermissionAction.cs
@@ -1,5 +1,11 @@
 ﻿namespace KinaUna.Data.Models.AccessManagement
 {
+    /// <summary>
+    /// Specifies the type of action to be performed in the context of a permission operation.
+    /// </summary>
+    /// <remarks>This enumeration is typically used to indicate the desired operation, such as adding,
+    /// updating, or deleting permissions. The <see cref="Unknown"/> value represents an undefined or uninitialized
+    /// state.</remarks>
     public enum PermissionAction
     {
         Unknown = 0,

--- a/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
+++ b/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
@@ -3,16 +3,80 @@ using System.ComponentModel.DataAnnotations;
 
 namespace KinaUna.Data.Models.AccessManagement
 {
+    /// <summary>
+    /// Represents an audit log entry for changes made to permissions within the system.
+    /// </summary>
+    /// <remarks>This class is used to track changes to permissions, including the type of permission, the
+    /// action performed, the user who made the change, and the state of the item before and after the change. It
+    /// supports logging for different types of permissions, such as family, progeny, and timeline item
+    /// permissions.</remarks>
     public class PermissionAuditLog
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the permission audit log entry.
+        /// </summary>
         [Key]
         public int PermissionAuditLogId { get; set; }
-        public int EntityId { get; set; } // FamilyId, ProgenyId or TimelineItemId
-        public string EntityType { get; set; } = string.Empty; // "Family", "Progeny" or "TimelineItem"
+
+        /// <summary>
+        /// Gets or sets the identifier for the progeny associated with this entity.
+        /// </summary>
+        public int ProgenyId { get; set; } = 0; // For ProgenyPermission and TimelineItemPermission only
+
+        /// <summary>
+        /// Gets or sets the identifier for the family associated with this entity.
+        /// </summary>
+        public int FamilyId { get; set; } = 0; // For FamilyPermission and TimelineItemPermission only
+
+        /// <summary>
+        /// Gets or sets the unique identifier for the timeline item.
+        /// </summary>
+        public int ItemId { get; set; } = 0; // For TimelineItemPermission only
+
+        /// <summary>
+        /// Gets or sets the type of the timeline item.
+        /// </summary>
+        public KinaUnaTypes.TimeLineType? TimelineType { get; set; } = null; // For timeline items only
+
+        /// <summary>
+        /// Gets or sets the unique identifier for a permission.
+        /// </summary>
+        public int PermissionId { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the type of permission associated with the entity (FamilyPermission, ProgenyPermission, TimelineItemPermission).
+        /// </summary>
+        /// <remarks>This property defines the category or scope of the permission. Ensure the value is 
+        /// meaningful within the application's context and adheres to the specified length constraint.</remarks>
+        [MaxLength(256)]
+        public string PermissionType { get; set; } = string.Empty; // "FamilyPermission", "ProgenyPermission", "TimelineItemPermission"
+        
+        /// <summary>
+        /// Gets or sets the action to be performed, such as "Add", "Update", or "Delete."
+        /// </summary>
         public PermissionAction Action { get; set; } = PermissionAction.Unknown; // "Add", "Update", "Delete"
+        
+        /// <summary>
+        /// Gets or sets the identifier of the user who made the change.
+        /// </summary>
+        [MaxLength(256)]
         public string ChangedBy { get; set; } = string.Empty; // UserId or email of the user who made the change
+
+        /// <summary>
+        /// The date and time when the change was made.
+        /// </summary>
         public DateTime ChangeTime { get; set; }
+
+        /// <summary>
+        /// JSON or text details of the item before the change.
+        /// </summary>
+        [MaxLength(8192)]
         public string ItemBefore { get; set; } = string.Empty; // JSON or text details of the change
+
+        /// <summary>
+        /// JSON or text details of the item after the change.
+        /// </summary>
+        [MaxLength(8192)]
         public string ItemAfter { get; set; } = string.Empty; // JSON or text details of the change
     }
 }

--- a/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
+++ b/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
@@ -9,7 +9,7 @@ namespace KinaUna.Data.Models.AccessManagement
         public int PermissionAuditLogId { get; set; }
         public int EntityId { get; set; } // FamilyId, ProgenyId or TimelineItemId
         public string EntityType { get; set; } = string.Empty; // "Family", "Progeny" or "TimelineItem"
-        public string Action { get; set; } = string.Empty; // "Add", "Update", "Delete"
+        public PermissionAction Action { get; set; } = PermissionAction.Unknown; // "Add", "Update", "Delete"
         public string ChangedBy { get; set; } = string.Empty; // UserId or email of the user who made the change
         public DateTime ChangeTime { get; set; }
         public string ItemBefore { get; set; } = string.Empty; // JSON or text details of the change

--- a/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
+++ b/KinaUna.Data/Models/AccessManagement/PermissionAuditLog.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace KinaUna.Data.Models.AccessManagement
+{
+    public class PermissionAuditLog
+    {
+        [Key]
+        public int PermissionAuditLogId { get; set; }
+        public int EntityId { get; set; } // FamilyId, ProgenyId or TimelineItemId
+        public string EntityType { get; set; } = string.Empty; // "Family", "Progeny" or "TimelineItem"
+        public string Action { get; set; } = string.Empty; // "Add", "Update", "Delete"
+        public string ChangedBy { get; set; } = string.Empty; // UserId or email of the user who made the change
+        public DateTime ChangeTime { get; set; }
+        public string ItemBefore { get; set; } = string.Empty; // JSON or text details of the change
+        public string ItemAfter { get; set; } = string.Empty; // JSON or text details of the change
+    }
+}

--- a/KinaUna.Data/Models/AccessManagement/UserGroupAction.cs
+++ b/KinaUna.Data/Models/AccessManagement/UserGroupAction.cs
@@ -1,0 +1,13 @@
+﻿namespace KinaUna.Data.Models.AccessManagement
+{
+    public enum UserGroupAction
+    {
+        Unknown = 0,
+        CreateGroup = 1,
+        UpdateGroup = 2,
+        DeleteGroup = 3,
+        AddGroupMember = 4,
+        UpdateGroupMember = 5,
+        RemoveGroupMember = 6
+    }
+}

--- a/KinaUna.Data/Models/AccessManagement/UserGroupAuditLog.cs
+++ b/KinaUna.Data/Models/AccessManagement/UserGroupAuditLog.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace KinaUna.Data.Models.AccessManagement
+{
+    public class UserGroupAuditLog
+    {
+        [Key]
+        public int UserGroupAuditLogId { get; set; }
+
+        public int UserGroupId { get; set; } = 0;
+        public int UserGroupMemberId { get; set; } = 0;
+
+        public UserGroupAction Action { get; set; } = UserGroupAction.Unknown; // E.g., CreateGroup, UpdateGroup, DeleteGroup, AddGroupMember, UpdateGroupMember, RemoveGroupMember
+        [MaxLength(256)]
+        public string EntityType { get; set; } = string.Empty; // E.g., "UserGroup", "UserGroupMember", etc.
+        [MaxLength(8192)]
+        public string EntityBefore { get; set; } = string.Empty; // JSON or text details of the item before the change
+
+        [MaxLength(8192)]
+        public string EntityAfter { get; set; } = string.Empty; // JSON or text details of the item after the change
+
+        [MaxLength(256)]
+        public string ChangedBy { get; set; }
+
+        public DateTime ChangeTime { get; set; }
+    }
+}

--- a/KinaUna.Data/Models/Family/FamilyAction.cs
+++ b/KinaUna.Data/Models/Family/FamilyAction.cs
@@ -1,0 +1,14 @@
+﻿namespace KinaUna.Data.Models.Family
+{
+    public enum FamilyAction
+    {
+        Unknown = 0,
+        CreateFamily = 1,
+        UpdateFamily = 2,
+        DeleteFamily = 3,
+        AddFamilyMember = 4,
+        UpdateFamilyMember = 5,
+        DeleteFamilyMember = 6,
+        ChangePermissionLevel = 7
+    }
+}

--- a/KinaUna.Data/Models/Family/FamilyAuditLog.cs
+++ b/KinaUna.Data/Models/Family/FamilyAuditLog.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace KinaUna.Data.Models.Family
+{
+    public class FamilyAuditLog
+    {
+        public int FamilyAuditLogId { get; set; }
+
+        public int FamilyId { get; set; } = 0; // For Family only, not FamilyMember
+        public int FamilyMemberId { get; set; } = 0; // For FamilyMember only
+        
+        public FamilyAction Action { get; set; } = FamilyAction.Unknown; // E.g., CreateFamily, UpdateFamily, DeleteFamily, AddFamilyMember, UpdateFamilyMember, RemoveFamilyMember
+
+        [MaxLength(256)]
+        public string EntityType { get; set; } = string.Empty; // E.g., "Family", "FamilyMember", etc.
+
+        [MaxLength(8192)]
+        public string EntityBefore { get; set; } = string.Empty; // JSON or text details of the item before the change
+
+        [MaxLength(8192)]
+        public string EntityAfter { get; set; } = string.Empty; // JSON or text details of the item after the change
+
+        [MaxLength(256)]
+        public string ChangedBy { get; set; }
+        
+        public DateTime ChangeTime { get; set; }
+        
+    }
+}

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925092535_AddFamilyAuditLogDb.Designer.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925092535_AddFamilyAuditLogDb.Designer.cs
@@ -4,16 +4,19 @@ using KinaUna.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace KinaUna.IDP.Migrations.ProgenyDb
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
 {
     [DbContext(typeof(ProgenyDbContext))]
-    partial class ProgenyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250925092535_AddFamilyAuditLogDb")]
+    partial class AddFamilyAuditLogDb
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925092535_AddFamilyAuditLogDb.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925092535_AddFamilyAuditLogDb.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
+{
+    /// <inheritdoc />
+    public partial class AddFamilyAuditLogDb : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FamilyAuditLogsDb",
+                columns: table => new
+                {
+                    FamilyAuditLogId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FamilyId = table.Column<int>(type: "int", nullable: false),
+                    FamilyMemberId = table.Column<int>(type: "int", nullable: false),
+                    Action = table.Column<int>(type: "int", nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EntityBefore = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true),
+                    EntityAfter = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true),
+                    ChangedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ChangeTime = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FamilyAuditLogsDb", x => x.FamilyAuditLogId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PermissionAuditLogsDb",
+                columns: table => new
+                {
+                    PermissionAuditLogId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ProgenyId = table.Column<int>(type: "int", nullable: false),
+                    FamilyId = table.Column<int>(type: "int", nullable: false),
+                    ItemId = table.Column<int>(type: "int", nullable: false),
+                    TimelineType = table.Column<int>(type: "int", nullable: true),
+                    PermissionId = table.Column<int>(type: "int", nullable: false),
+                    PermissionType = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    Action = table.Column<int>(type: "int", nullable: false),
+                    ChangedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ChangeTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ItemBefore = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true),
+                    ItemAfter = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PermissionAuditLogsDb", x => x.PermissionAuditLogId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FamilyAuditLogsDb");
+
+            migrationBuilder.DropTable(
+                name: "PermissionAuditLogsDb");
+        }
+    }
+}

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925094957_AddUserGroupAuditLogDb.Designer.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925094957_AddUserGroupAuditLogDb.Designer.cs
@@ -4,16 +4,19 @@ using KinaUna.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace KinaUna.IDP.Migrations.ProgenyDb
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
 {
     [DbContext(typeof(ProgenyDbContext))]
-    partial class ProgenyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250925094957_AddUserGroupAuditLogDb")]
+    partial class AddUserGroupAuditLogDb
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925094957_AddUserGroupAuditLogDb.cs
+++ b/KinaUna.OpenIddict/Migrations/ProgenyDb/20250925094957_AddUserGroupAuditLogDb.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KinaUna.OpenIddict.Migrations.ProgenyDb
+{
+    /// <inheritdoc />
+    public partial class AddUserGroupAuditLogDb : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserGroupAuditLogsDb",
+                columns: table => new
+                {
+                    UserGroupAuditLogId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserGroupId = table.Column<int>(type: "int", nullable: false),
+                    UserGroupMemberId = table.Column<int>(type: "int", nullable: false),
+                    Action = table.Column<int>(type: "int", nullable: false),
+                    EntityType = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    EntityBefore = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true),
+                    EntityAfter = table.Column<string>(type: "nvarchar(max)", maxLength: 8192, nullable: true),
+                    ChangedBy = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
+                    ChangeTime = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserGroupAuditLogsDb", x => x.UserGroupAuditLogId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserGroupAuditLogsDb");
+        }
+    }
+}

--- a/KinaUnaProgenyApi/Services/AccessManagementService/AccessManagementService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/AccessManagementService.cs
@@ -119,7 +119,9 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
 
             progenyDbContext.TimelineItemPermissionsDb.Add(timelineItemPermission);
             await progenyDbContext.SaveChangesAsync();
-
+            
+            await permissionAuditLogService.AddTimelineItemPermissionAuditLogEntry(PermissionAction.Add, timelineItemPermission, currentUserInfo);
+            
             return timelineItemPermission; // Todo: Use result object instead.
         }
 
@@ -169,9 +171,14 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                     }
                 }
             }
-            
+
+            PermissionAuditLog logEntry = await permissionAuditLogService.AddTimelineItemPermissionAuditLogEntry(PermissionAction.Delete, existingPermission, currentUserInfo);
+
             progenyDbContext.TimelineItemPermissionsDb.Remove(existingPermission);
             await progenyDbContext.SaveChangesAsync();
+
+            logEntry.ItemAfter = System.Text.Json.JsonSerializer.Serialize(existingPermission);
+            await permissionAuditLogService.UpdatePermissionAuditLogEntry(logEntry);
 
             return true; // Todo: Use result object instead.
         }
@@ -224,13 +231,18 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                     }
                 }
             }
-            
+
+            PermissionAuditLog logEntry = await permissionAuditLogService.AddTimelineItemPermissionAuditLogEntry(PermissionAction.Update, existingPermission, currentUserInfo);
+
             existingPermission.PermissionLevel = timelineItemPermission.PermissionLevel;
             existingPermission.ModifiedTime = System.DateTime.UtcNow;
             existingPermission.ModifiedBy = currentUserInfo.UserId;
 
             progenyDbContext.TimelineItemPermissionsDb.Update(existingPermission);
             await progenyDbContext.SaveChangesAsync();
+
+            logEntry.ItemAfter = System.Text.Json.JsonSerializer.Serialize(existingPermission);
+            await permissionAuditLogService.UpdatePermissionAuditLogEntry(logEntry);
 
             return existingPermission; // Todo: Use result object instead.
         }
@@ -304,7 +316,22 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             {
                 return null; // Todo: Use result object instead.
             }
-
+            
+            // If the new permission is admin, add to the Progeny Admins list.
+            if (progenyPermission.PermissionLevel == PermissionLevel.Admin)
+            {
+                Progeny progeny = await progenyDbContext.ProgenyDb.SingleOrDefaultAsync(p => p.Id == progenyPermission.ProgenyId);
+                if (progeny != null)
+                {
+                    if (!progeny.IsInAdminList(progenyPermission.Email))
+                    {
+                        progeny.AddToAdminList(progenyPermission.Email);
+                        progenyDbContext.ProgenyDb.Update(progeny);
+                        await progenyDbContext.SaveChangesAsync();
+                    }
+                }
+            }
+            
             progenyPermission.CreatedBy = currentUserInfo.UserId;
             progenyPermission.CreatedTime = System.DateTime.UtcNow;
             progenyPermission.ModifiedBy = currentUserInfo.UserId;
@@ -314,6 +341,7 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             await progenyDbContext.SaveChangesAsync();
 
             await permissionAuditLogService.AddProgenyPermissionAuditLogEntry(PermissionAction.Add, progenyPermission, currentUserInfo);
+
             return progenyPermission; // Todo: Use result object instead.
         }
 
@@ -542,6 +570,21 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 return null; // Todo: Use result object instead.
             }
 
+            // If the new permission is admin, add to the Family Admins list.
+            if (familyPermission.PermissionLevel == PermissionLevel.Admin)
+            {
+                Family family = await progenyDbContext.FamiliesDb.SingleOrDefaultAsync(f => f.FamilyId == familyPermission.FamilyId);
+                if (family != null)
+                {
+                    if (!family.IsInAdminList(familyPermission.Email))
+                    {
+                        family.AddToAdminList(familyPermission.Email);
+                        progenyDbContext.FamiliesDb.Update(family);
+                        await progenyDbContext.SaveChangesAsync();
+                    }
+                }
+            }
+
             familyPermission.CreatedBy = currentUserInfo.UserId;
             familyPermission.CreatedTime = System.DateTime.UtcNow;
             familyPermission.ModifiedBy = currentUserInfo.UserId;
@@ -549,6 +592,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             
             progenyDbContext.FamilyPermissionsDb.Add(familyPermission);
             await progenyDbContext.SaveChangesAsync();
+
+            await permissionAuditLogService.AddFamilyPermissionAuditLogEntry(PermissionAction.Add, familyPermission, currentUserInfo);
 
             return familyPermission; // Todo: Use result object instead.
         }
@@ -591,6 +636,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 }
             }
 
+            PermissionAuditLog logEntry = await permissionAuditLogService.AddFamilyPermissionAuditLogEntry(PermissionAction.Delete, familyPermission, currentUserInfo);
+
             // If the existing permission is admin, remove from Family Admins list.
             if (existingPermission.PermissionLevel == PermissionLevel.Admin)
             {
@@ -607,7 +654,10 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             
             progenyDbContext.FamilyPermissionsDb.Remove(existingPermission);
             await progenyDbContext.SaveChangesAsync();
-            
+
+            logEntry.ItemAfter = System.Text.Json.JsonSerializer.Serialize(existingPermission);
+            await permissionAuditLogService.UpdatePermissionAuditLogEntry(logEntry);
+
             return true; // Todo: Use result object instead.
         }
 
@@ -645,6 +695,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 }
             }
 
+            PermissionAuditLog logEntry = await permissionAuditLogService.AddFamilyPermissionAuditLogEntry(PermissionAction.Update, familyPermission, currentUserInfo);
+
             // If the existing permission is admin and the new permission isn't, remove from Family Admins list.
             if (familyPermission.PermissionLevel == PermissionLevel.Admin && existingPermission.PermissionLevel != PermissionLevel.Admin)
             {
@@ -680,6 +732,9 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             progenyDbContext.FamilyPermissionsDb.Update(existingPermission);
             await progenyDbContext.SaveChangesAsync();
             
+            logEntry.ItemAfter = System.Text.Json.JsonSerializer.Serialize(existingPermission);
+            await permissionAuditLogService.UpdatePermissionAuditLogEntry(logEntry);
+
             return existingPermission; // Todo: Use result object instead.
         }
         

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
@@ -1,0 +1,6 @@
+﻿namespace KinaUnaProgenyApi.Services.AccessManagementService
+{
+    public interface IPermissionAuditLogService
+    {
+    }
+}

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
@@ -6,7 +6,11 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
     public interface IPermissionAuditLogService
     {
+        Task<PermissionAuditLog> GetPermissionAuditLogEntry(int permissionAuditLogId);
+        Task<PermissionAuditLog> AddPermissionAuditLogEntry(PermissionAuditLog logEntry);
         Task<PermissionAuditLog> UpdatePermissionAuditLogEntry(PermissionAuditLog logEntry);
+        Task<PermissionAuditLog> AddTimelineItemPermissionAuditLogEntry(PermissionAction action, TimelineItemPermission itemPermissionBefore, UserInfo userInfo);
         Task<PermissionAuditLog> AddProgenyPermissionAuditLogEntry(PermissionAction action, ProgenyPermission progenyPermissionBefore, UserInfo userInfo);
+        Task<PermissionAuditLog> AddFamilyPermissionAuditLogEntry(PermissionAction action, FamilyPermission familyPermissionBefore, UserInfo userInfo);
     }
 }

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
@@ -1,6 +1,12 @@
-﻿namespace KinaUnaProgenyApi.Services.AccessManagementService
+﻿using KinaUna.Data.Models;
+using KinaUna.Data.Models.AccessManagement;
+using System.Threading.Tasks;
+
+namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
     public interface IPermissionAuditLogService
     {
+        Task<PermissionAuditLog> UpdatePermissionAuditLogEntry(PermissionAuditLog logEntry);
+        Task<PermissionAuditLog> AddProgenyPermissionAuditLogEntry(PermissionAction action, ProgenyPermission progenyPermissionBefore, UserInfo userInfo);
     }
 }

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IPermissionAuditLogService.cs
@@ -4,13 +4,77 @@ using System.Threading.Tasks;
 
 namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
+    /// <summary>
+    /// Provides functionality for managing and auditing permission changes in the system.
+    /// </summary>
+    /// <remarks>This service is responsible for creating, updating, and retrieving audit log entries related
+    /// to permission changes. It supports logging changes for various permission types, including timeline item
+    /// permissions, progeny permissions,  and family permissions. Each log entry includes details about the change,
+    /// such as the action performed, the user  who made the change, and the state of the item before and after the
+    /// change.</remarks>
     public interface IPermissionAuditLogService
     {
+        /// <summary>
+        /// Retrieves a specific permission audit log entry by its unique identifier.
+        /// </summary>
+        /// <param name="permissionAuditLogId">The unique identifier of the permission audit log entry to retrieve.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the requested audit log entry,  or <see
+        /// langword="null"/> if no entry with the specified identifier exists.</returns>
         Task<PermissionAuditLog> GetPermissionAuditLogEntry(int permissionAuditLogId);
+
+        /// <summary>
+        /// Adds a new permission audit log entry to the database.
+        /// </summary>
+        /// <param name="logEntry">The permission audit log entry to add.</param>
+        /// <returns>The added permission audit log entry.</returns>
         Task<PermissionAuditLog> AddPermissionAuditLogEntry(PermissionAuditLog logEntry);
+
+        /// <summary>
+        /// Updates an existing permission audit log entry with the current timestamp and saves the changes to the
+        /// database.
+        /// </summary>
+        /// <remarks>This method updates the <see cref="PermissionAuditLog.ChangeTime"/> property to the
+        /// current UTC time before saving the changes to the database. Ensure that the provided <paramref
+        /// name="logEntry"/> represents a valid and existing database entry.</remarks>
+        /// <param name="logEntry">The <see cref="PermissionAuditLog"/> object to update. The object must already exist in the database.</param>
+        /// <returns>The updated <see cref="PermissionAuditLog"/> object.</returns>
         Task<PermissionAuditLog> UpdatePermissionAuditLogEntry(PermissionAuditLog logEntry);
+
+        /// <summary>
+        /// Adds a new permission audit log entry for a timeline item.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to record changes made to a timeline item's
+        /// permissions.  The log entry includes details such as the action performed, the user who made the change, and
+        /// the state of the item before the change.</remarks>
+        /// <param name="action">The action performed on the timeline item permission. For example, add, update, or delete.</param>
+        /// <param name="itemPermissionBefore">The state of the timeline item permission before the action was performed.</param>
+        /// <param name="userInfo">Information about the user who performed the action.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         Task<PermissionAuditLog> AddTimelineItemPermissionAuditLogEntry(PermissionAction action, TimelineItemPermission itemPermissionBefore, UserInfo userInfo);
+
+        /// <summary>
+        /// Adds a new audit log entry for a change in progeny permissions.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to track changes made to progeny permissions.
+        /// The log entry includes details  such as the type of action performed, the state of the permission before the
+        /// change, and the user who made the change.  The log entry is saved to the database asynchronously.</remarks>
+        /// <param name="action">The action performed on the progeny permission, such as Create, Update, or Delete.</param>
+        /// <param name="progenyPermissionBefore">The state of the progeny permission before the change was made.</param>
+        /// <param name="userInfo">Information about the user who performed the action, including their user ID or email.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         Task<PermissionAuditLog> AddProgenyPermissionAuditLogEntry(PermissionAction action, ProgenyPermission progenyPermissionBefore, UserInfo userInfo);
+
+        /// <summary>
+        /// Adds a new audit log entry for a family permission change.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to track changes made to family permissions.
+        /// The log entry includes details  such as the family ID, permission ID, the type of permission, the action
+        /// performed, the user who made the change,  and the timestamp of the change. The state of the permission
+        /// before the change is serialized and stored in the log.</remarks>
+        /// <param name="action">The action performed on the family permission, such as create, update, or delete.</param>
+        /// <param name="familyPermissionBefore">The state of the family permission before the change occurred.</param>
+        /// <param name="userInfo">Information about the user who performed the action, including their user ID or email.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         Task<PermissionAuditLog> AddFamilyPermissionAuditLogEntry(PermissionAction action, FamilyPermission familyPermissionBefore, UserInfo userInfo);
     }
 }

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IUserGroupAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IUserGroupAuditLogService.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using KinaUna.Data.Models;
+using KinaUna.Data.Models.AccessManagement;
+
+namespace KinaUnaProgenyApi.Services.AccessManagementService
+{
+    public interface IUserGroupAuditLogService
+    {
+        Task<UserGroupAuditLog> GetUserGroupAuditLogEntry(int userGroupAuditLogId);
+        Task<UserGroupAuditLog> AddUserGroupAuditLogEntry(UserGroupAuditLog logEntry);
+        Task<UserGroupAuditLog> UpdateUserGroupAuditLogEntry(UserGroupAuditLog logEntry);
+        Task<UserGroupAuditLog> AddUserGroupCreatedAuditLogEntry(UserGroup userGroup, UserInfo userInfo);
+        Task<UserGroupAuditLog> AddUserGroupUpdatedAuditLogEntry(UserGroup userGroup, UserInfo userInfo);
+        Task<UserGroupAuditLog> AddUserGroupDeletedAuditLogEntry(UserGroup userGroup, UserInfo userInfo);
+        Task<UserGroupAuditLog> AddUserGroupMemberAddedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo);
+        Task<UserGroupAuditLog> AddUserGroupMemberUpdatedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo);
+        Task<UserGroupAuditLog> AddUserGroupMemberDeletedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo);
+    }
+}

--- a/KinaUnaProgenyApi/Services/AccessManagementService/IUserGroupService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/IUserGroupService.cs
@@ -2,7 +2,7 @@
 using KinaUna.Data.Models.AccessManagement;
 using System.Threading.Tasks;
 
-namespace KinaUnaProgenyApi.Services
+namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
     public interface IUserGroupService
     {

--- a/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
@@ -1,7 +1,52 @@
-﻿namespace KinaUnaProgenyApi.Services.AccessManagementService
+﻿using System.Text.Json;
+using System.Threading.Tasks;
+using KinaUna.Data.Contexts;
+using KinaUna.Data.Models;
+using KinaUna.Data.Models.AccessManagement;
+using Microsoft.EntityFrameworkCore;
+
+namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
-    public class PermissionAuditLogService: IPermissionAuditLogService
+    public class PermissionAuditLogService(ProgenyDbContext progenyDbContext): IPermissionAuditLogService
     {
+        public async Task<PermissionAuditLog> AddPermissionAuditLogEntry(PermissionAuditLog logEntry)
+        {
+            progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+            return logEntry;
+        }
+
+        public async Task<PermissionAuditLog> UpdatePermissionAuditLogEntry(PermissionAuditLog logEntry)
+        {
+            progenyDbContext.PermissionAuditLogsDb.Update(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+            return logEntry;
+        }
+
+        public async Task<PermissionAuditLog?> GetPermissionAuditLogEntry(int permissionAuditLogId)
+        {
+            PermissionAuditLog? logEntry = await progenyDbContext.PermissionAuditLogsDb.AsNoTracking().SingleOrDefaultAsync(pau => pau.PermissionAuditLogId == permissionAuditLogId);
+            return logEntry;
+        }
+
+        public async Task<PermissionAuditLog> AddProgenyPermissionAuditLogEntry(PermissionAction action, ProgenyPermission progenyPermissionBefore, UserInfo userInfo)
+        {
+            PermissionAuditLog logEntry = new PermissionAuditLog
+            {
+                EntityId = progenyPermissionBefore.ProgenyPermissionId,
+                EntityType = nameof(ProgenyPermission),
+                Action = action,
+                ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
+                ChangeTime = System.DateTime.UtcNow,
+                ItemBefore = JsonSerializer.Serialize(progenyPermissionBefore),
+                ItemAfter = string.Empty
+            };
+
+            progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+            
+            return logEntry;
+        }
 
     }
 }

--- a/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
@@ -7,34 +7,83 @@ using Microsoft.EntityFrameworkCore;
 
 namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
+    /// <summary>
+    /// Provides functionality for managing and auditing permission changes in the system.
+    /// </summary>
+    /// <remarks>This service is responsible for creating, updating, and retrieving audit log entries related
+    /// to permission changes. It supports logging changes for various permission types, including timeline item
+    /// permissions, progeny permissions,  and family permissions. Each log entry includes details about the change,
+    /// such as the action performed, the user  who made the change, and the state of the item before and after the
+    /// change.</remarks>
+    /// <param name="progenyDbContext"></param>
     public class PermissionAuditLogService(ProgenyDbContext progenyDbContext): IPermissionAuditLogService
     {
+        /// <summary>
+        /// Adds a new permission audit log entry to the database.
+        /// </summary>
+        /// <param name="logEntry">The permission audit log entry to add.</param>
+        /// <returns>The added permission audit log entry.</returns>
         public async Task<PermissionAuditLog> AddPermissionAuditLogEntry(PermissionAuditLog logEntry)
         {
+            logEntry.ChangeTime = System.DateTime.UtcNow;
+
             progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
             await progenyDbContext.SaveChangesAsync();
+            
             return logEntry;
         }
 
+        /// <summary>
+        /// Updates an existing permission audit log entry with the current timestamp and saves the changes to the
+        /// database.
+        /// </summary>
+        /// <remarks>This method updates the <see cref="PermissionAuditLog.ChangeTime"/> property to the
+        /// current UTC time before saving the changes to the database. Ensure that the provided <paramref
+        /// name="logEntry"/> represents a valid and existing database entry.</remarks>
+        /// <param name="logEntry">The <see cref="PermissionAuditLog"/> object to update. The object must already exist in the database.</param>
+        /// <returns>The updated <see cref="PermissionAuditLog"/> object.</returns>
         public async Task<PermissionAuditLog> UpdatePermissionAuditLogEntry(PermissionAuditLog logEntry)
         {
+            logEntry.ChangeTime = System.DateTime.UtcNow;
+            
             progenyDbContext.PermissionAuditLogsDb.Update(logEntry);
             await progenyDbContext.SaveChangesAsync();
+            
             return logEntry;
         }
 
+        /// <summary>
+        /// Retrieves a specific permission audit log entry by its unique identifier.
+        /// </summary>
+        /// <param name="permissionAuditLogId">The unique identifier of the permission audit log entry to retrieve.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the requested audit log entry,  or <see
+        /// langword="null"/> if no entry with the specified identifier exists.</returns>
         public async Task<PermissionAuditLog> GetPermissionAuditLogEntry(int permissionAuditLogId)
         {
-            PermissionAuditLog? logEntry = await progenyDbContext.PermissionAuditLogsDb.AsNoTracking().SingleOrDefaultAsync(pau => pau.PermissionAuditLogId == permissionAuditLogId);
+            PermissionAuditLog logEntry = await progenyDbContext.PermissionAuditLogsDb.AsNoTracking().SingleOrDefaultAsync(pau => pau.PermissionAuditLogId == permissionAuditLogId);
             return logEntry;
         }
 
+        /// <summary>
+        /// Adds a new permission audit log entry for a timeline item.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to record changes made to a timeline item's
+        /// permissions.  The log entry includes details such as the action performed, the user who made the change, and
+        /// the state of the item before the change.</remarks>
+        /// <param name="action">The action performed on the timeline item permission. For example, add, update, or delete.</param>
+        /// <param name="itemPermissionBefore">The state of the timeline item permission before the action was performed.</param>
+        /// <param name="userInfo">Information about the user who performed the action.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         public async Task<PermissionAuditLog> AddTimelineItemPermissionAuditLogEntry(PermissionAction action, TimelineItemPermission itemPermissionBefore, UserInfo userInfo)
         {
             PermissionAuditLog logEntry = new PermissionAuditLog
             {
-                EntityId = itemPermissionBefore.TimelineItemPermissionId,
-                EntityType = nameof(TimelineItemPermission),
+                ProgenyId = itemPermissionBefore.ProgenyId,
+                FamilyId = itemPermissionBefore.FamilyId,
+                ItemId = itemPermissionBefore.ItemId,
+                TimelineType = itemPermissionBefore.TimelineType,
+                PermissionId = itemPermissionBefore.TimelineItemPermissionId,
+                PermissionType = nameof(TimelineItemPermission),
                 Action = action,
                 ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
                 ChangeTime = System.DateTime.UtcNow,
@@ -48,12 +97,23 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             return logEntry;
         }
 
+        /// <summary>
+        /// Adds a new audit log entry for a change in progeny permissions.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to track changes made to progeny permissions.
+        /// The log entry includes details  such as the type of action performed, the state of the permission before the
+        /// change, and the user who made the change.  The log entry is saved to the database asynchronously.</remarks>
+        /// <param name="action">The action performed on the progeny permission, such as Create, Update, or Delete.</param>
+        /// <param name="progenyPermissionBefore">The state of the progeny permission before the change was made.</param>
+        /// <param name="userInfo">Information about the user who performed the action, including their user ID or email.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         public async Task<PermissionAuditLog> AddProgenyPermissionAuditLogEntry(PermissionAction action, ProgenyPermission progenyPermissionBefore, UserInfo userInfo)
         {
             PermissionAuditLog logEntry = new PermissionAuditLog
             {
-                EntityId = progenyPermissionBefore.ProgenyPermissionId,
-                EntityType = nameof(ProgenyPermission),
+                ProgenyId = progenyPermissionBefore.ProgenyId,
+                PermissionId = progenyPermissionBefore.ProgenyPermissionId,
+                PermissionType = nameof(ProgenyPermission),
                 Action = action,
                 ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
                 ChangeTime = System.DateTime.UtcNow,
@@ -67,12 +127,24 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             return logEntry;
         }
 
+        /// <summary>
+        /// Adds a new audit log entry for a family permission change.
+        /// </summary>
+        /// <remarks>This method creates an audit log entry to track changes made to family permissions.
+        /// The log entry includes details  such as the family ID, permission ID, the type of permission, the action
+        /// performed, the user who made the change,  and the timestamp of the change. The state of the permission
+        /// before the change is serialized and stored in the log.</remarks>
+        /// <param name="action">The action performed on the family permission, such as create, update, or delete.</param>
+        /// <param name="familyPermissionBefore">The state of the family permission before the change occurred.</param>
+        /// <param name="userInfo">Information about the user who performed the action, including their user ID or email.</param>
+        /// <returns>A <see cref="PermissionAuditLog"/> object representing the newly created audit log entry.</returns>
         public async Task<PermissionAuditLog> AddFamilyPermissionAuditLogEntry(PermissionAction action, FamilyPermission familyPermissionBefore, UserInfo userInfo)
         {
             PermissionAuditLog logEntry = new PermissionAuditLog
             {
-                EntityId = familyPermissionBefore.FamilyPermissionId,
-                EntityType = nameof(FamilyPermission),
+                FamilyId = familyPermissionBefore.FamilyId,
+                PermissionId = familyPermissionBefore.FamilyPermissionId,
+                PermissionType = nameof(FamilyPermission),
                 Action = action,
                 ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
                 ChangeTime = System.DateTime.UtcNow,

--- a/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
@@ -23,9 +23,28 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             return logEntry;
         }
 
-        public async Task<PermissionAuditLog?> GetPermissionAuditLogEntry(int permissionAuditLogId)
+        public async Task<PermissionAuditLog> GetPermissionAuditLogEntry(int permissionAuditLogId)
         {
             PermissionAuditLog? logEntry = await progenyDbContext.PermissionAuditLogsDb.AsNoTracking().SingleOrDefaultAsync(pau => pau.PermissionAuditLogId == permissionAuditLogId);
+            return logEntry;
+        }
+
+        public async Task<PermissionAuditLog> AddTimelineItemPermissionAuditLogEntry(PermissionAction action, TimelineItemPermission itemPermissionBefore, UserInfo userInfo)
+        {
+            PermissionAuditLog logEntry = new PermissionAuditLog
+            {
+                EntityId = itemPermissionBefore.TimelineItemPermissionId,
+                EntityType = nameof(TimelineItemPermission),
+                Action = action,
+                ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
+                ChangeTime = System.DateTime.UtcNow,
+                ItemBefore = JsonSerializer.Serialize(itemPermissionBefore),
+                ItemAfter = string.Empty
+            };
+
+            progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
             return logEntry;
         }
 
@@ -45,6 +64,25 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
             await progenyDbContext.SaveChangesAsync();
             
+            return logEntry;
+        }
+
+        public async Task<PermissionAuditLog> AddFamilyPermissionAuditLogEntry(PermissionAction action, FamilyPermission familyPermissionBefore, UserInfo userInfo)
+        {
+            PermissionAuditLog logEntry = new PermissionAuditLog
+            {
+                EntityId = familyPermissionBefore.FamilyPermissionId,
+                EntityType = nameof(FamilyPermission),
+                Action = action,
+                ChangedBy = !string.IsNullOrEmpty(userInfo.UserId) ? userInfo.UserId : userInfo.UserEmail,
+                ChangeTime = System.DateTime.UtcNow,
+                ItemBefore = JsonSerializer.Serialize(familyPermissionBefore),
+                ItemAfter = string.Empty
+            };
+
+            progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
             return logEntry;
         }
 

--- a/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
@@ -91,6 +91,13 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 ItemAfter = string.Empty
             };
 
+            if (action == PermissionAction.Add)
+            {
+                // Swap ItemBefore and ItemAfter for Add actions
+                logEntry.ItemAfter = logEntry.ItemBefore;
+                logEntry.ItemBefore = string.Empty;
+            }
+
             progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
             await progenyDbContext.SaveChangesAsync();
 
@@ -120,6 +127,13 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 ItemBefore = JsonSerializer.Serialize(progenyPermissionBefore),
                 ItemAfter = string.Empty
             };
+
+            if (action == PermissionAction.Add)
+            {
+                // Swap ItemBefore and ItemAfter for Add actions
+                logEntry.ItemAfter = logEntry.ItemBefore;
+                logEntry.ItemBefore = string.Empty;
+            }
 
             progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
             await progenyDbContext.SaveChangesAsync();
@@ -151,6 +165,13 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
                 ItemBefore = JsonSerializer.Serialize(familyPermissionBefore),
                 ItemAfter = string.Empty
             };
+
+            if (action == PermissionAction.Add)
+            {
+                // Swap ItemBefore and ItemAfter for Add actions
+                logEntry.ItemAfter = logEntry.ItemBefore;
+                logEntry.ItemBefore = string.Empty;
+            }
 
             progenyDbContext.PermissionAuditLogsDb.Add(logEntry);
             await progenyDbContext.SaveChangesAsync();

--- a/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/PermissionAuditLogService.cs
@@ -1,0 +1,7 @@
+﻿namespace KinaUnaProgenyApi.Services.AccessManagementService
+{
+    public class PermissionAuditLogService: IPermissionAuditLogService
+    {
+
+    }
+}

--- a/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupAuditLogService.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Threading.Tasks;
+using KinaUna.Data.Contexts;
+using KinaUna.Data.Models;
+using KinaUna.Data.Models.AccessManagement;
+using Microsoft.EntityFrameworkCore;
+
+namespace KinaUnaProgenyApi.Services.AccessManagementService
+{
+    public class UserGroupAuditLogService(ProgenyDbContext progenyDbContext): IUserGroupAuditLogService
+    {
+        public async Task<UserGroupAuditLog> GetUserGroupAuditLogEntry(int logEntryId)
+        {
+            return await progenyDbContext.UserGroupAuditLogsDb.SingleOrDefaultAsync(u => u.UserGroupAuditLogId == logEntryId);
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupAuditLogEntry(UserGroupAuditLog logEntry)
+        {
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+        public async Task<UserGroupAuditLog> UpdateUserGroupAuditLogEntry(UserGroupAuditLog logEntry)
+        {
+            progenyDbContext.UserGroupAuditLogsDb.Update(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupCreatedAuditLogEntry(UserGroup userGroup, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroup.UserGroupId,
+                Action = UserGroupAction.CreateGroup ,
+                EntityType = nameof(UserGroup),
+                EntityBefore = string.Empty,
+                EntityAfter = System.Text.Json.JsonSerializer.Serialize(userGroup),
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupUpdatedAuditLogEntry(UserGroup userGroup, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroup.UserGroupId,
+                Action = UserGroupAction.UpdateGroup,
+                EntityType = nameof(UserGroup),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(userGroup),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupDeletedAuditLogEntry(UserGroup userGroup, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroup.UserGroupId,
+                Action = UserGroupAction.DeleteGroup,
+                EntityType = nameof(UserGroup),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(userGroup),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupMemberAddedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroupMember.UserGroupId,
+                UserGroupMemberId = userGroupMember.UserGroupMemberId,
+                Action = UserGroupAction.AddGroupMember,
+                EntityType = nameof(UserGroupMember),
+                EntityBefore = string.Empty,
+                EntityAfter = System.Text.Json.JsonSerializer.Serialize(userGroupMember),
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupMemberUpdatedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroupMember.UserGroupId,
+                UserGroupMemberId = userGroupMember.UserGroupMemberId,
+                Action = UserGroupAction.UpdateGroupMember,
+                EntityType = nameof(UserGroupMember),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(userGroupMember),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<UserGroupAuditLog> AddUserGroupMemberDeletedAuditLogEntry(UserGroupMember userGroupMember, UserInfo userInfo)
+        {
+            UserGroupAuditLog logEntry = new()
+            {
+                UserGroupId = userGroupMember.UserGroupId,
+                UserGroupMemberId = userGroupMember.UserGroupMemberId,
+                Action = UserGroupAction.RemoveGroupMember,
+                EntityType = nameof(UserGroupMember),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(userGroupMember),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+            await progenyDbContext.UserGroupAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+    }
+}

--- a/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupService.cs
@@ -89,6 +89,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
 
             progenyDbContext.UserGroupsDb.Add(userGroup);
             await progenyDbContext.SaveChangesAsync();
+
+            // Todo: Audit log entry.
             return userGroup;
         }
 
@@ -134,6 +136,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             group.ModifiedTime = DateTime.UtcNow;
             
             await progenyDbContext.SaveChangesAsync();
+
+            // Todo: Audit log entry.
             return group;
         }
 
@@ -181,6 +185,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             
             progenyDbContext.UserGroupsDb.Remove(group);
             await progenyDbContext.SaveChangesAsync();
+
+            // Todo: Audit log entry.
             return true;
         }
 
@@ -242,7 +248,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
 
             progenyDbContext.UserGroupMembersDb.Add(userGroupMember);
             await progenyDbContext.SaveChangesAsync();
-            
+
+            // Todo: Audit log entry.
             return userGroupMember;
         }
 
@@ -301,7 +308,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             member.ModifiedTime = DateTime.UtcNow;
             
             await progenyDbContext.SaveChangesAsync();
-            
+
+            // Todo: Audit log entry.
             return member;
         }
 
@@ -343,7 +351,8 @@ namespace KinaUnaProgenyApi.Services.AccessManagementService
             
             progenyDbContext.UserGroupMembersDb.Remove(member);
             await progenyDbContext.SaveChangesAsync();
-            
+
+            // Todo: Audit log entry.
             return true;
         }
         

--- a/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupService.cs
+++ b/KinaUnaProgenyApi/Services/AccessManagementService/UserGroupService.cs
@@ -5,10 +5,9 @@ using System.Threading.Tasks;
 using KinaUna.Data.Contexts;
 using KinaUna.Data.Models;
 using KinaUna.Data.Models.AccessManagement;
-using KinaUnaProgenyApi.Services.AccessManagementService;
 using Microsoft.EntityFrameworkCore;
 
-namespace KinaUnaProgenyApi.Services
+namespace KinaUnaProgenyApi.Services.AccessManagementService
 {
     /// <summary>
     /// User group service. Handles user groups and their members.

--- a/KinaUnaProgenyApi/Services/FamilyServices/FamilyAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/FamilyServices/FamilyAuditLogService.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Threading.Tasks;
+using KinaUna.Data.Contexts;
+using KinaUna.Data.Models;
+using KinaUna.Data.Models.Family;
+
+namespace KinaUnaProgenyApi.Services.FamilyServices
+{
+    public class FamilyAuditLogService(ProgenyDbContext progenyDbContext): IFamilyAuditLogService
+    {
+        public async Task<FamilyAuditLog> AddFamilyAuditLogEntry(FamilyAuditLog logEntry)
+        {
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> UpdateFamilyAuditLogEntry(FamilyAuditLog logEntry)
+        {
+            progenyDbContext.FamilyAuditLogsDb.Update(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> AddFamilyCreatedAuditLogEntry(Family family, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyId = family.FamilyId,
+                Action = FamilyAction.CreateFamily,
+                EntityType = nameof(Family),
+                EntityBefore = string.Empty,
+                EntityAfter = System.Text.Json.JsonSerializer.Serialize(family),
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+            
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> AddFamilyUpdatedAuditLogEntry(Family family, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyId = family.FamilyId,
+                Action = FamilyAction.UpdateFamily,
+                EntityType = nameof(Family),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(family),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> AddFamilyDeletedAuditLogEntry(Family family, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyId = family.FamilyId,
+                Action = FamilyAction.DeleteFamily,
+                EntityType = nameof(Family),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(family),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+
+        public async Task<FamilyAuditLog> AddFamilyMemberAddedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyMemberId = familyMember.FamilyMemberId,
+                FamilyId = familyMember.FamilyId,
+                Action = FamilyAction.AddFamilyMember,
+                EntityType = nameof(FamilyMember),
+                EntityBefore = string.Empty,
+                EntityAfter = System.Text.Json.JsonSerializer.Serialize(familyMember),
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> AddFamilyMemberUpdatedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyMemberId = familyMember.FamilyMemberId,
+                FamilyId = familyMember.FamilyId,
+                Action = FamilyAction.UpdateFamilyMember,
+                EntityType = nameof(FamilyMember),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(familyMember),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+
+        public async Task<FamilyAuditLog> AddFamilyMemberDeletedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo)
+        {
+            FamilyAuditLog logEntry = new()
+            {
+                FamilyMemberId = familyMember.FamilyMemberId,
+                FamilyId = familyMember.FamilyId,
+                Action = FamilyAction.DeleteFamilyMember,
+                EntityType = nameof(FamilyMember),
+                EntityBefore = System.Text.Json.JsonSerializer.Serialize(familyMember),
+                EntityAfter = string.Empty,
+                ChangedBy = userInfo.UserId,
+                ChangeTime = DateTime.UtcNow
+            };
+
+            await progenyDbContext.FamilyAuditLogsDb.AddAsync(logEntry);
+            await progenyDbContext.SaveChangesAsync();
+
+            return logEntry;
+        }
+    }
+}

--- a/KinaUnaProgenyApi/Services/FamilyServices/FamilyMembersService.cs
+++ b/KinaUnaProgenyApi/Services/FamilyServices/FamilyMembersService.cs
@@ -225,7 +225,7 @@ namespace KinaUnaProgenyApi.Services.FamilyServices
             await progenyDbContext.SaveChangesAsync();
 
             logEntry.EntityAfter = System.Text.Json.JsonSerializer.Serialize(existingFamilyMember);
-            progenyDbContext.FamilyAuditLogsDb.Update(logEntry);
+            await familyAuditLogService.UpdateFamilyAuditLogEntry(logEntry);
 
             return existingFamilyMember;
         }

--- a/KinaUnaProgenyApi/Services/FamilyServices/FamilyService.cs
+++ b/KinaUnaProgenyApi/Services/FamilyServices/FamilyService.cs
@@ -132,6 +132,7 @@ namespace KinaUnaProgenyApi.Services.FamilyServices
             // Add the family to the database.
             await progenyDbContext.FamiliesDb.AddAsync(family);
             await progenyDbContext.SaveChangesAsync();
+            // Todo: Audit log entry.
 
             // Add FamilyPermissions for all admins in the family.
             foreach (string adminEmail in family.GetAdminsList())
@@ -197,6 +198,7 @@ namespace KinaUnaProgenyApi.Services.FamilyServices
 
             progenyDbContext.FamiliesDb.Update(existingFamily);
             await progenyDbContext.SaveChangesAsync();
+            // Todo: Audit log entry.
 
             // Add FamilyPermissions for new admins
             foreach (string newAdmin in newAdmins)
@@ -239,9 +241,7 @@ namespace KinaUnaProgenyApi.Services.FamilyServices
                     _ = await accessManagementService.UpdateFamilyPermission(familyPermission, currentUserInfo);
                 }
             }
-
-            // Todo: Audit log the update of the family.
-
+            
             return existingFamily;
         }
 

--- a/KinaUnaProgenyApi/Services/FamilyServices/IFamilyAuditLogService.cs
+++ b/KinaUnaProgenyApi/Services/FamilyServices/IFamilyAuditLogService.cs
@@ -1,0 +1,18 @@
+﻿using KinaUna.Data.Models.Family;
+using System.Threading.Tasks;
+using KinaUna.Data.Models;
+
+namespace KinaUnaProgenyApi.Services.FamilyServices
+{
+    public interface IFamilyAuditLogService
+    {
+        Task<FamilyAuditLog> AddFamilyAuditLogEntry(FamilyAuditLog logEntry);
+        Task<FamilyAuditLog> UpdateFamilyAuditLogEntry(FamilyAuditLog logEntry);
+        Task<FamilyAuditLog> AddFamilyCreatedAuditLogEntry(Family family, UserInfo userInfo);
+        Task<FamilyAuditLog> AddFamilyUpdatedAuditLogEntry(Family family, UserInfo userInfo);
+        Task<FamilyAuditLog> AddFamilyDeletedAuditLogEntry(Family family, UserInfo userInfo);
+        Task<FamilyAuditLog> AddFamilyMemberAddedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo);
+        Task<FamilyAuditLog> AddFamilyMemberUpdatedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo);
+        Task<FamilyAuditLog> AddFamilyMemberDeletedAuditLogEntry(FamilyMember familyMember, UserInfo userInfo);
+    }
+}

--- a/KinaUnaProgenyApi/Startup.cs
+++ b/KinaUnaProgenyApi/Startup.cs
@@ -99,6 +99,7 @@ namespace KinaUnaProgenyApi
             services.AddScoped<IKanbanBoardsService, KanbanBoardsService>();
             services.AddScoped<IAccessManagementService, AccessManagementService>();
             services.AddScoped<IUserGroupService, UserGroupService>();
+            services.AddScoped<IUserGroupAuditLogService, UserGroupAuditLogService>();
             services.AddScoped<IFamilyService, FamilyService>();
             services.AddScoped<IFamilyMembersService, FamilyMembersService>();
             services.AddScoped<IFamilyAuditLogService, FamilyAuditLogService>();

--- a/KinaUnaProgenyApi/Startup.cs
+++ b/KinaUnaProgenyApi/Startup.cs
@@ -101,6 +101,7 @@ namespace KinaUnaProgenyApi
             services.AddScoped<IUserGroupService, UserGroupService>();
             services.AddScoped<IFamilyService, FamilyService>();
             services.AddScoped<IFamilyMembersService, FamilyMembersService>();
+            services.AddScoped<IPermissionAuditLogService, PermissionAuditLogService>();
             services.AddTransient<IEmailSender, EmailSender>();
             services.AddHostedService<TimedSchedulerService>();
             services.AddControllers().AddNewtonsoftJson();

--- a/KinaUnaProgenyApi/Startup.cs
+++ b/KinaUnaProgenyApi/Startup.cs
@@ -101,6 +101,7 @@ namespace KinaUnaProgenyApi
             services.AddScoped<IUserGroupService, UserGroupService>();
             services.AddScoped<IFamilyService, FamilyService>();
             services.AddScoped<IFamilyMembersService, FamilyMembersService>();
+            services.AddScoped<IFamilyAuditLogService, FamilyAuditLogService>();
             services.AddScoped<IPermissionAuditLogService, PermissionAuditLogService>();
             services.AddTransient<IEmailSender, EmailSender>();
             services.AddHostedService<TimedSchedulerService>();

--- a/KinaUnaProgenyApi/Startup.cs
+++ b/KinaUnaProgenyApi/Startup.cs
@@ -143,7 +143,8 @@ namespace KinaUnaProgenyApi
                 services.AddCors(options => options.AddDefaultPolicy(policy =>
                     policy.AllowAnyHeader()
                         .AllowAnyMethod()
-                        .WithOrigins(Constants.DevelopmentCorsList)));
+                        .WithOrigins(Constants.DevelopmentCorsList)
+                        .SetPreflightMaxAge(TimeSpan.FromMinutes(15))));
             }
             // If production, restrict to the specified origin.
             else
@@ -153,7 +154,8 @@ namespace KinaUnaProgenyApi
                     services.AddCors(options => options.AddDefaultPolicy(policy =>
                         policy.AllowAnyHeader()
                             .AllowAnyMethod()
-                            .WithOrigins(Constants.StagingCorsList)));
+                            .WithOrigins(Constants.StagingCorsList)
+                            .SetPreflightMaxAge(TimeSpan.FromMinutes(15))));
                 }
                 else
                 {

--- a/KinaUnaWeb/Startup.cs
+++ b/KinaUnaWeb/Startup.cs
@@ -212,7 +212,8 @@ namespace KinaUnaWeb
                 services.AddCors(options => options.AddDefaultPolicy(policy =>
                     policy.AllowAnyHeader()
                         .AllowAnyMethod()
-                        .WithOrigins(Constants.DevelopmentCorsList)));
+                        .WithOrigins(Constants.DevelopmentCorsList)
+                        .SetPreflightMaxAge(TimeSpan.FromMinutes(15))));
             }
             // If production, restrict to the specified origin.
             else
@@ -222,7 +223,8 @@ namespace KinaUnaWeb
                     services.AddCors(options => options.AddDefaultPolicy(policy =>
                         policy.AllowAnyHeader()
                             .AllowAnyMethod()
-                            .WithOrigins(Constants.StagingCorsList)));
+                            .WithOrigins(Constants.StagingCorsList)
+                            .SetPreflightMaxAge(TimeSpan.FromMinutes(15))));
                 }
                 else
                 {


### PR DESCRIPTION
This pull request introduces a new auditing system for access management and family operations, adding audit log entities, enums for action types, and database migrations to persist audit logs. It also begins integrating audit logging into the access management service for timeline item permissions. The most important changes are summarized below:

**Audit Log Entities and Action Enums**

* Added new entity classes: `PermissionAuditLog`, `FamilyAuditLog`, and `UserGroupAuditLog` to track changes to permissions, families, and user groups, respectively. Each entity includes properties to record the action, before/after state, user, and timestamp. [[1]](diffhunk://#diff-46621f4b5979ab2c0c884be11ac7085ecdb422fec742538cc4ed951e4fe2b2ddR1-R82) [[2]](diffhunk://#diff-2572ac29f231cc73e1c9382009ce8101623442e43c83edbd45b5305ee9d77cd9R1-R30) [[3]](diffhunk://#diff-43785181718a1e1374cb9092741ce1710c8f025718bf92167657f7ffffd5a57dR1-R28)
* Introduced enums `PermissionAction`, `FamilyAction`, and `UserGroupAction` to standardize the types of actions being audited (e.g., Add, Update, Delete, etc.). [[1]](diffhunk://#diff-c084d6771a858ddf183cfb3401bf2f1a93ec375cf57fe22aded8df54fd61a2f8R1-R16) [[2]](diffhunk://#diff-eb0ad91d03026c1a1172e762524570bfddf9736523a9757e18cc748da7a282bfR1-R14) [[3]](diffhunk://#diff-bf2eab878eed25b025720242323f5a84a5dc62bdb8a78703bf610b59e9f1a47bR1-R13)

**Database Context and Migrations**

* Updated `ProgenyDbContext` to include new `DbSet`s for the audit log entities, enabling their use in the application and migrations.
* Added database migrations to create the `PermissionAuditLogsDb`, `FamilyAuditLogsDb`, and `UserGroupAuditLogsDb` tables, and updated the EF Core model snapshot accordingly. [[1]](diffhunk://#diff-c416775781aa3310e8294230082947f12e6bdc0c9b36be85a4bcecda04701013R1-R67) [[2]](diffhunk://#diff-2b9a8b2b46faf16e3946856a49aa1426eee5c25c23a0654130bcb3a6c0b2f50fR1-R41) [[3]](diffhunk://#diff-e717d7f321b9ab896c3fb4c83636608b19c68bb84667ffa64dbe996bb7b577b3R69-R118) [[4]](diffhunk://#diff-e717d7f321b9ab896c3fb4c83636608b19c68bb84667ffa64dbe996bb7b577b3R260-R300) [[5]](diffhunk://#diff-e717d7f321b9ab896c3fb4c83636608b19c68bb84667ffa64dbe996bb7b577b3R595-R635)

**Integration in Access Management Service**

* Modified `AccessManagementService` to accept an `IPermissionAuditLogService` and started using it to log timeline item permission grants and revocations. This includes creating audit log entries when permissions are added or deleted, and updating the log entry after deletion. [[1]](diffhunk://#diff-c50b51deb8a49e991ec076da75b285edcd73153abb6123edf5f2467e7be784fdL17-R17) [[2]](diffhunk://#diff-c50b51deb8a49e991ec076da75b285edcd73153abb6123edf5f2467e7be784fdR123-R124) [[3]](diffhunk://#diff-c50b51deb8a49e991ec076da75b285edcd73153abb6123edf5f2467e7be784fdR175-R182)